### PR TITLE
Fix 'easily' typo in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@
 - Disaster recovery implementation
 - Automated documentation
 - Dev, QA (automated), staging, and production environment
-- Cloudagnostic (can easiliy be migrated to another cloud provider such as Digital Ocean/Hetzner/Linode/Render.com/Railway.com
+- Cloudagnostic (can easily be migrated to another cloud provider such as Digital Ocean/Hetzner/Linode/Render.com/Railway.com
 
 </details>
 

--- a/Writerside/topics/README1.md
+++ b/Writerside/topics/README1.md
@@ -76,7 +76,7 @@ The ultimate purpose is to deploy the projects I have wanted to fullfill for a l
 - Disaster recovery implementation
 - Automated documentation
 - Dev, QA (automated), staging, and production environment
-- Cloudagnostic (can easiliy be migrated to another cloud provider such as digialocean/linode/Cloudservers.dk/Render.com
+- Cloudagnostic (can easily be migrated to another cloud provider such as digialocean/linode/Cloudservers.dk/Render.com
 
 </details>
 

--- a/Writerside/topics/topics_README.md
+++ b/Writerside/topics/topics_README.md
@@ -78,7 +78,7 @@ The ultimate purpose is to deploy the projects I have wanted to fullfill for a l
 - Disaster recovery implementation
 - Automated documentation
 - Dev, QA (automated), staging, and production environment
-- Cloudagnostic (can easiliy be migrated to another cloud provider such as digialocean/linode/Cloudservers.dk/Render.com
+- Cloudagnostic (can easily be migrated to another cloud provider such as digialocean/linode/Cloudservers.dk/Render.com
 
 </details>
 


### PR DESCRIPTION
## Summary
- fix minor spelling error in README and Writerside docs

## Testing
- `dotnet test --no-build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684b62918258832195b2c4ac9d52f661