### PR TITLE
Add null token validation test for TokenStorageService

### DIFF
--- a/Code/AppBlueprint/AppBlueprint.Tests/Infrastructure/TokenStorageServiceTests.cs
+++ b/Code/AppBlueprint/AppBlueprint.Tests/Infrastructure/TokenStorageServiceTests.cs
@@ -61,5 +61,15 @@ namespace AppBlueprint.Tests.Infrastructure
             // Assert
             _jsRuntimeMock.Verify(js => js.InvokeVoidAsync("localStorage.removeItem", StorageKey), Times.Once);
         }
+
+        [Test]
+        public async Task StoreTokenAsync_ShouldThrowArgumentNullException_WhenTokenIsNull()
+        {
+            // Act
+            Func<Task> act = () => _tokenStorageService.StoreTokenAsync(null!);
+
+            // Assert
+            await act.Should().ThrowAsync<ArgumentNullException>();
+        }
     }
 }


### PR DESCRIPTION
## Summary
- cover null token validation in TokenStorageService tests

## Testing
- `dotnet test --no-build --verbosity minimal` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b63411c108321981c9f6df0140440