### PR TITLE
fix: remove Kestrel port configuration conflicts for Railway deployment

### DIFF
--- a/Code/AppBlueprint/AppBlueprint.ApiService/Program.cs
+++ b/Code/AppBlueprint/AppBlueprint.ApiService/Program.cs
@@ -28,27 +28,10 @@ internal static class Program // Make class static
            options.ValidateOnBuild = true;
        });
 
-        // Configure Kestrel ports based on environment
-        builder.WebHost.ConfigureKestrel(options =>
-        {
-            if (builder.Environment.IsDevelopment())
-            {
-                // Development: Use non-privileged ports that don't require admin
-                options.ListenAnyIP(8081); // HTTP on 8081
-                options.ListenAnyIP(8082, listenOptions =>
-                {
-                    listenOptions.UseHttps();
-                });
-                Console.WriteLine("[API] Development mode - HTTP (8081) and HTTPS (8082) enabled");
-            }
-            else
-            {
-                // Production (Railway): Use port 80 as Railway expects
-                // TLS is handled at the edge/load balancer
-                options.ListenAnyIP(80);
-                Console.WriteLine("[API] Production mode - HTTP (80) enabled, TLS handled by Railway");
-            }
-        });
+        // Port configuration handled by ASPNETCORE_URLS environment variable:
+        // - Development: Set via launchSettings.json or appsettings (http://localhost:8081)
+        // - Production: Set via Dockerfile ENV ASPNETCORE_URLS=http://+:80 (Railway handles SSL termination)
+        // No ConfigureKestrel needed - avoids conflicts with environment variables
 
         // Add services to the container.
         builder.Services.AddProblemDetails();

--- a/Code/AppBlueprint/AppBlueprint.Web/Program.cs
+++ b/Code/AppBlueprint/AppBlueprint.Web/Program.cs
@@ -85,26 +85,10 @@ var navigationRoutes = builder.Configuration
     .Get<List<NavLinkMetadata>>() ?? new List<NavLinkMetadata>();
 builder.Services.AddSingleton(navigationRoutes);
 
-// Configure Kestrel to listen on all interfaces for both development and production
-builder.WebHost.ConfigureKestrel(options =>
-{
-    if (builder.Environment.IsDevelopment())
-    {
-        // Development: HTTP and HTTPS with dev certificates
-        options.ListenAnyIP(80); // HTTP
-        options.ListenAnyIP(443, listenOptions =>
-        {
-            listenOptions.UseHttps(); // Uses the ASP.NET Core dev certificate
-        });
-        Console.WriteLine("[Web] Development mode - Listening on 0.0.0.0:80 (HTTP) and 0.0.0.0:443 (HTTPS)");
-    }
-    else
-    {
-        // Production (Railway): Only HTTP, SSL/TLS handled by Railway's load balancer
-        options.ListenAnyIP(80); // HTTP only
-        Console.WriteLine("[Web] Production mode - Listening on 0.0.0.0:80 (HTTP only), TLS handled by Railway");
-    }
-});
+// Port configuration handled by ASPNETCORE_URLS environment variable:
+// - Development: Set via launchSettings.json (http://localhost:5000;https://localhost:5001)
+// - Production: Set via Dockerfile ENV ASPNETCORE_URLS=http://+:80 (Railway handles SSL termination)
+// No ConfigureKestrel needed - avoids conflicts with environment variables
 
 builder.Services.ConfigureHttpClientDefaults(http =>
 {


### PR DESCRIPTION
- Removed ConfigureKestrel blocks that conflicted with ASPNETCORE_URLS
- Now rely solely on ASPNETCORE_URLS environment variable (http://+:80)
- Fixes "connection refused" error in Railway production environment
- Eliminates port binding warnings and conflicts
- Simpler configuration for cloud deployment where edge handles SSL

### Summary & Motivation

A brief description of the changes in this pull request explaining why these changes are necessary. Please delete this paragraph.

### Checklist for Pull Request - Merge from development into main (production) branch

- [ ] A Label has been added to the Pull Request
- [ ] Automated tests have been added
- [ ] Documentation has been updated automatically or manual
