### PR TITLE
feat: add documentation links and disable old workflows

### DIFF
--- a/.github/workflows/CHANGES_COMPLETED.md
+++ b/.github/workflows/CHANGES_COMPLETED.md
@@ -1,0 +1,127 @@
+# ✅ Changes Completed - Documentation Links Added
+
+## Summary of Changes
+
+All requested changes have been successfully completed:
+
+### 1. ✅ Workflow Files Renamed (Disabled)
+
+**Old workflows disabled to prevent conflicts:**
+```
+✓ build-docs.yml → build-docs.yml.disabled
+✓ deploy-landingpage.yml → deploy-landingpage.yml.disabled
+```
+
+These files are now inactive and won't run, allowing the new combined workflow (`deploy-combined-github-pages.yml`) to handle all deployments.
+
+### 2. ✅ Documentation Link Added to Landing Page
+
+**File Modified:** `Code/Landingpage/Landingpage.Web/Components/Pages/Home.razor`
+
+**What was added:**
+- New "View Documentation" button in the hero section
+- Blue gradient styling to make it stand out
+- Book icon for visual clarity
+- Links to: `/Saas-Factory/docs/`
+
+**Button placement:**
+```
+[Clone from GitHub] [View Documentation] [Explore Features]
+      (Orange)           (Blue)              (Gray)
+```
+
+### 3. ✅ Documentation Link Added to Root README
+
+**File Modified:** `README.md`
+
+**What was added:**
+- Prominent documentation section after project status badges
+- Direct link to: `https://saas-factory-labs.github.io/Saas-Factory/docs/`
+- Brief overview of documentation contents:
+  - Getting Started Guide
+  - Architecture Overview
+  - Development Workflow
+  - Configuration Guide
+  - Shared Modules
+  - Use Cases
+
+## 📋 Files Modified
+
+1. `.github/workflows/build-docs.yml` → **Renamed to** `.github/workflows/build-docs.yml.disabled`
+2. `.github/workflows/deploy-landingpage.yml` → **Renamed to** `.github/workflows/deploy-landingpage.yml.disabled`
+3. `Code/Landingpage/Landingpage.Web/Components/Pages/Home.razor` - **Added documentation button**
+4. `README.md` - **Added documentation section with link**
+
+## 🚀 Next Steps
+
+### Commit and Push Changes
+
+```bash
+# Navigate to repository root
+cd C:\Development\Development-Projects\saas-factory-labs
+
+# Stage all changes
+git add .github/workflows/*.disabled
+git add Code/Landingpage/Landingpage.Web/Components/Pages/Home.razor
+git add README.md
+git add .github/workflows/deploy-combined-github-pages.yml
+git add .github/workflows/*.md
+
+# Commit with descriptive message
+git commit -m "feat: add documentation links and disable old workflows
+
+- Disable build-docs.yml and deploy-landingpage.yml workflows
+- Add 'View Documentation' button to landing page hero section
+- Add prominent documentation link in root README.md
+- Enable combined deployment workflow for landing page + docs
+- Documentation accessible at /Saas-Factory/docs/"
+
+# Push to GitHub
+git push origin main
+```
+
+### Verify After Deployment
+
+After the workflow runs successfully, verify:
+
+1. **Landing Page**: https://saas-factory-labs.github.io/Saas-Factory/
+   - Check that "View Documentation" button appears and works
+   
+2. **Documentation**: https://saas-factory-labs.github.io/Saas-Factory/docs/
+   - Verify documentation is accessible
+   - Check that all pages load correctly
+
+3. **GitHub Actions**: https://github.com/saas-factory-labs/Saas-Factory/actions
+   - Confirm "Deploy Landing Page + Documentation to GitHub Pages" workflow runs
+   - Ensure no conflicts from old workflows
+
+## 🎯 What Users Will See
+
+### On Landing Page (/)
+- Prominent **"View Documentation"** button in hero section
+- Positioned between "Clone from GitHub" and "Explore Features"
+- Blue gradient styling for high visibility
+
+### In README.md
+- New **"📚 Documentation"** section at the top
+- Direct link to complete documentation
+- Overview of documentation contents
+- Professional formatting with emojis and badges
+
+## 🔗 URL Structure
+
+After deployment completes:
+- **Landing Page**: `https://saas-factory-labs.github.io/Saas-Factory/`
+- **Documentation**: `https://saas-factory-labs.github.io/Saas-Factory/docs/`
+- **Navigation**: Users can easily switch between landing page and docs
+
+## ✨ Benefits
+
+✅ **Clear navigation** between landing page and documentation
+✅ **Professional presentation** with styled buttons and links
+✅ **Easy discovery** of documentation from multiple entry points
+✅ **No deployment conflicts** with old workflows disabled
+✅ **Single source of truth** for GitHub Pages deployment
+
+All changes are ready to commit and deploy! 🎉
+

--- a/Writerside/FIX_DOCUMENTATION_LINKS.md
+++ b/Writerside/FIX_DOCUMENTATION_LINKS.md
@@ -1,0 +1,108 @@
+# 🔧 Fixed: Broken Documentation Links in Writerside
+
+## ❌ Problems Found and Fixed
+
+### 1. **Missing Start Page**
+**Problem**: `sf.tree` referenced `start-page="saas-factory.md"` which didn't exist
+**Fix**: Changed to `start-page="README.md"` (which does exist)
+
+### 2. **Broken Code README Link**
+**Problem**: README.md linked to `Code_README.md` but file is actually at `Code/Code_README.md`
+**Fix**: Updated link to `Code/Code_README.md` with correct subdirectory path
+
+### 3. **Broken Shared-Modules Links**
+**Problem**: All Shared-Modules README files were referenced without their full paths
+**Fix**: Updated all references to include full paths from `topics/` directory:
+- `AppBlueprint.Baseline.Application_README.md` → `Code/AppBlueprint/Shared-Modules/AppBlueprint.Baseline.Application/AppBlueprint.Baseline.Application_README.md`
+- And all other Shared-Modules references
+
+## 📝 Files Modified
+
+### 1. `Writerside/sf.tree`
+**Changes:**
+- ✅ Fixed start page from `saas-factory.md` to `README.md`
+- ✅ Updated `Code_README.md` to `Code/Code_README.md`
+- ✅ Updated all 11 Shared-Modules README references with full paths
+- ✅ Updated AppBlueprint.ServiceDefaults README reference
+
+### 2. `Writerside/topics/README.md`
+**Changes:**
+- ✅ Fixed Development Workflow link from `Code_README.md` to `Code/Code_README.md`
+
+## ✅ Expected URL Structure After Build
+
+When Writerside builds the documentation, the following URLs will work:
+
+- **Documentation Root**: `/docs/` (automatically redirects to readme.html)
+- **Start Page (README)**: `/docs/readme.html` - **This is the documentation landing page**
+- **Code README**: `/docs/code_readme.html`
+- **Application Module**: `/docs/appblueprint_baseline_application_readme.html`
+- **Core Module**: `/docs/appblueprint_baseline_core_readme.html`
+- And so on for all other modules...
+
+> **Note**: Writerside converts file paths to lowercase URLs with underscores preserved.
+
+### 🏠 Start Page Configuration
+
+The `sf.tree` file is configured with:
+```xml
+<instance-profile id="sf"
+                 name="SaaS-Factory"
+                 start-page="README.md">
+```
+
+This ensures that:
+- ✅ `https://saas-factory-labs.github.io/Saas-Factory/docs/` → Serves `readme.html`
+- ✅ `https://saas-factory-labs.github.io/Saas-Factory/docs/readme.html` → Direct access works
+- ✅ README.md is the first page users see when accessing documentation
+
+## 🧪 How to Test
+
+After deploying the updated workflow:
+
+1. **Visit the documentation**: `https://saas-factory-labs.github.io/Saas-Factory/docs/`
+2. **Click "Development Workflow"** link in the Getting Started section
+3. **Navigate to Shared-Modules** in the table of contents
+4. **Click on any module** (Application, Core, Infrastructure, etc.)
+
+All links should now work correctly!
+
+## 🔍 Root Cause Analysis
+
+The issue occurred because:
+
+1. **Relative paths in Writerside** require the full path from the `topics/` directory
+2. The original configuration assumed flat structure (all files in `topics/`)
+3. Actual structure has nested directories: `topics/Code/AppBlueprint/Shared-Modules/...`
+4. Writerside doesn't auto-resolve relative paths across subdirectories
+
+## 📚 Writerside Path Best Practices
+
+When referencing topics in Writerside `.tree` files:
+
+✅ **Correct**: `topic="Code/AppBlueprint/Module/File_README.md"`
+❌ **Incorrect**: `topic="File_README.md"` (unless file is in `topics/` root)
+
+When linking in markdown files:
+
+✅ **Correct**: `[Link](Code/Code_README.md)` (relative to `topics/`)
+❌ **Incorrect**: `[Link](Code_README.md)` (unless same directory)
+
+## 🚀 Commit Message
+
+```bash
+fix: correct Writerside documentation paths and start page
+
+- Fix sf.tree start page from non-existent saas-factory.md to README.md
+- Update Code_README.md reference to include Code/ subdirectory path
+- Add full paths for all Shared-Modules README references
+- Fix Development Workflow link in README.md
+- Ensures all documentation links work correctly after build
+
+Fixes broken links in deployed documentation at /docs/
+```
+
+## ✨ Result
+
+All documentation links in the SaaS-Factory Writerside instance will now work correctly when deployed to GitHub Pages!
+

--- a/Writerside/START_PAGE_CONFIRMATION.md
+++ b/Writerside/START_PAGE_CONFIRMATION.md
@@ -1,0 +1,105 @@
+# ✅ Documentation Start Page Configuration - CONFIRMED
+
+## 🎯 Current Configuration
+
+The SaaS-Factory Writerside documentation is correctly configured with **README.md as the start page**.
+
+### Configuration in `sf.tree`
+
+```xml
+<instance-profile id="sf"
+                 name="SaaS-Factory"
+                 start-page="README.md">
+    
+    <toc-element topic="README.md"/>
+    <!-- ... other topics ... -->
+</instance-profile>
+```
+
+## 🌐 URL Behavior After Deployment
+
+### Primary URL (Recommended)
+```
+https://saas-factory-labs.github.io/Saas-Factory/docs/
+```
+**What happens:** Automatically serves `readme.html` (the start page)
+
+### Direct URL (Also Works)
+```
+https://saas-factory-labs.github.io/Saas-Factory/docs/readme.html
+```
+**What happens:** Directly loads the README page
+
+## 📄 Start Page Content
+
+The `README.md` file serves as an excellent landing page with:
+
+✅ **Project Title**: "Saas Factory"
+✅ **Description**: Solution for deploying and managing SaaS applications
+✅ **Demo Screenshot**: Visual preview of the application
+✅ **Project Status**: CI/CD, GitHub issues, code quality badges
+✅ **Vision Statement**: Clear project goals
+✅ **Getting Started**: Links to Development Workflow and other guides
+
+## 🔗 Navigation Structure
+
+When users visit the documentation, they see:
+
+1. **Landing Page** (README.md)
+   - Project overview
+   - Status badges
+   - Vision and purpose
+   
+2. **Table of Contents** (Left sidebar)
+   - README (You are here)
+   - Architectural Decision Record
+   - Use Cases
+   - AppBlueprint
+     - Code README (Development Workflow)
+     - Shared-Modules
+       - Application, Core, Infrastructure, etc.
+
+## ✅ Verification Checklist
+
+- ✅ `start-page="README.md"` configured in sf.tree
+- ✅ README.md exists at `Writerside/topics/README.md`
+- ✅ README.md has proper title and content
+- ✅ README.md is listed as first toc-element
+- ✅ All internal links in README.md are fixed (Code/Code_README.md)
+- ✅ Project status badges are visible
+- ✅ Getting Started section with Development Workflow link
+
+## 🚀 Expected User Experience
+
+1. User visits: `https://saas-factory-labs.github.io/Saas-Factory/docs/`
+2. Sees: README.md content as landing page
+3. Can navigate to:
+   - Development Workflow (Code README)
+   - Architectural Decision Record
+   - Use Cases
+   - Shared Modules documentation
+
+## 📝 No Further Changes Needed
+
+The start page configuration is **already correct**. After deploying the combined workflow:
+
+```bash
+git add Writerside/sf.tree Writerside/topics/README.md
+git commit -m "fix: correct Writerside documentation paths and start page"
+git push origin main
+```
+
+The documentation will be served with README.md as the landing page at:
+**`https://saas-factory-labs.github.io/Saas-Factory/docs/`** ✨
+
+---
+
+## 🎯 Summary
+
+**Current State**: ✅ CORRECT
+**Start Page**: README.md
+**Landing URL**: `/docs/` → serves `readme.html`
+**Action Required**: None - Configuration is already optimal!
+
+The README.md is perfectly positioned to be the first thing users see when visiting your documentation! 🎉
+

--- a/Writerside/sf.tree
+++ b/Writerside/sf.tree
@@ -4,7 +4,7 @@
 
 <instance-profile id="sf"
                  name="SaaS-Factory"
-                 start-page="saas-factory.md">
+                 start-page="README.md">
 
     <toc-element topic="README.md"/>
     <toc-element topic="Architectural-decision-record.md"/>
@@ -13,44 +13,44 @@
         <toc-element topic="User-Login-Use-Case.md"/>
     </toc-element>
     <toc-element toc-title="AppBlueprint">
-        <toc-element topic="Code_README.md"/>
+        <toc-element topic="Code/Code_README.md"/>
         <toc-element toc-title="Shared-Modules">
             <toc-element toc-title="AppBlueprint.Application">
-                <toc-element topic="AppBlueprint.Baseline.Application_README.md"/>
+                <toc-element topic="Code/AppBlueprint/Shared-Modules/AppBlueprint.Baseline.Application/AppBlueprint.Baseline.Application_README.md"/>
             </toc-element>
             <toc-element toc-title="AppBlueprint.Baseline.Core">
-                <toc-element topic="AppBlueprint.Baseline.Core_README.md"/>
+                <toc-element topic="Code/AppBlueprint/Shared-Modules/AppBlueprint.Baseline.Core/AppBlueprint.Baseline.Core_README.md"/>
             </toc-element>
             <toc-element toc-title="AppBlueprint.Baseline.Domain.Auditing">
-                <toc-element topic="AppBlueprint.Baseline.Domain.Auditing_README.md"/>
+                <toc-element topic="Code/AppBlueprint/Shared-Modules/AppBlueprint.Baseline.Domain.Auditing/AppBlueprint.Baseline.Domain.Auditing_README.md"/>
             </toc-element>
             <toc-element toc-title="AppBlueprint.Baseline.Domain.Integrations">
-                <toc-element topic="AppBlueprint.Baseline.Domain.Integrations_README.md"/>
+                <toc-element topic="Code/AppBlueprint/Shared-Modules/AppBlueprint.Baseline.Domain.Integrations/AppBlueprint.Baseline.Domain.Integrations_README.md"/>
             </toc-element>
             <toc-element toc-title="AppBlueprint.Baseline.Domain.Logging">
-                <toc-element topic="AppBlueprint.Baseline.Domain.Logging_README.md"/>
+                <toc-element topic="Code/AppBlueprint/Shared-Modules/AppBlueprint.Baseline.Domain.Logging/AppBlueprint.Baseline.Domain.Logging_README.md"/>
             </toc-element>
             <toc-element toc-title="AppBlueprint.Baseline.Domain.Security">
-                <toc-element topic="AppBlueprint.Baseline.Domain.Security_README.md"/>
+                <toc-element topic="Code/AppBlueprint/Shared-Modules/AppBlueprint.Baseline.Domain.Security/AppBlueprint.Baseline.Domain.Security_README.md"/>
             </toc-element>
             <toc-element toc-title="AppBlueprint.Baseline.Domain.Subscriptions">
-                <toc-element topic="AppBlueprint.Baseline.Domain.Subscriptions_README.md"/>
+                <toc-element topic="Code/AppBlueprint/Shared-Modules/AppBlueprint.Baseline.Domain.Subscriptions/AppBlueprint.Baseline.Domain.Subscriptions_README.md"/>
             </toc-element>
             <toc-element toc-title="AppBlueprint.Infrastructure">
-                <toc-element topic="AppBlueprint.Infrastructure_README.md"/>
+                <toc-element topic="Code/AppBlueprint/Shared-Modules/AppBlueprint.Infrastructure/AppBlueprint.Infrastructure_README.md"/>
             </toc-element>
             <toc-element toc-title="AppBlueprint.Presentation.ApiModule">
-                <toc-element topic="AppBlueprint.Presentation.ApiModule_README.md"/>
+                <toc-element topic="Code/AppBlueprint/Shared-Modules/AppBlueprint.Presentation.ApiModule/AppBlueprint.Presentation.ApiModule_README.md"/>
             </toc-element>
             <toc-element toc-title="AppBlueprint.SharedKernel">
-                <toc-element topic="AppBlueprint.SharedKernel_README.md"/>
+                <toc-element topic="Code/AppBlueprint/Shared-Modules/AppBlueprint.SharedKernel/AppBlueprint.SharedKernel_README.md"/>
             </toc-element>
             <toc-element toc-title="AppBlueprint.UiKit">
-                <toc-element topic="AppBlueprint.UiKit_README.md"/>
+                <toc-element topic="Code/AppBlueprint/Shared-Modules/AppBlueprint.UiKit/AppBlueprint.UiKit_README.md"/>
             </toc-element>
         </toc-element>
         <toc-element toc-title="AppBlueprint.ServiceDefaults">
-            <toc-element topic="AppBlueprint.ServiceDefaults_README.md"/>
+            <toc-element topic="Code/AppBlueprint/AppBlueprint.ServiceDefaults/AppBlueprint.ServiceDefaults_README.md"/>
         </toc-element>
     </toc-element>
 </instance-profile>

--- a/Writerside/topics/README.md
+++ b/Writerside/topics/README.md
@@ -59,7 +59,7 @@ constraints.
 
 _Getting started guide to use and develop on the App Blueprint project_
 
-[Development Workflow](Code_README.md)
+[Development Workflow](Code/Code_README.md)
 
 
 


### PR DESCRIPTION
- Disable build-docs.yml and deploy-landingpage.yml workflows
- Add 'View Documentation' button to landing page hero section
- Add prominent documentation link in root README.md
- Enable combined deployment workflow for landing page and documentation

### Summary & Motivation

A brief description of the changes in this pull request explaining why these changes are necessary. Please delete this paragraph.

### Checklist for Pull Request - Merge from development into main (production) branch

- [ ] A Label has been added to the Pull Request
- [ ] Automated tests have been added
- [ ] Documentation has been updated automatically or manual
