### PR TITLE
fix(docs): Fix Tailwind CSS build in GitHub Actions using standalone …

### DIFF
--- a/.github/workflows/deploy-combined-github-pages.yml
+++ b/.github/workflows/deploy-combined-github-pages.yml
@@ -82,11 +82,21 @@ jobs:
           dotnet build . --configuration Release
           echo "✅ .NET project built"
 
+      - name: Install Tailwind CSS standalone binary
+        run: |
+          echo "📥 Installing Tailwind CSS standalone binary..."
+          mkdir -p /home/runner/.local/bin
+          curl -o "/home/runner/.local/bin/tailwindcss" -L "https://github.com/tailwindlabs/tailwindcss/releases/latest/download/tailwindcss-linux-x64"
+          chmod +x /home/runner/.local/bin/tailwindcss
+          export PATH="/home/runner/.local/bin:$PATH"
+          echo "/home/runner/.local/bin" >> $GITHUB_PATH
+          echo "✅ Tailwind CSS binary installed"
+
       - name: Build Tailwind CSS
         working-directory: docs/RazorPress/RazorPress
         run: |
           echo "🎨 Building Tailwind CSS..."
-          npm run build
+          /home/runner/.local/bin/tailwindcss -i ./tailwind.input.css -o ./wwwroot/css/app.css --minify
           echo "✅ Tailwind CSS built"
           
           # Verify CSS was generated


### PR DESCRIPTION
…binary

- Add <base href> tag to _Layout.cshtml for subdirectory deployments
- Install and use standalone Tailwind CSS binary instead of npm package
- Refactor workflow to configure PublicBaseUrl for GitHub Pages
- Add verification checks for generated assets

The Tailwind CSS v4 npm package doesn't provide a CLI executable for npx, causing builds to fail in GitHub Actions. Switched to using the official standalone binary which works consistently across environments.

Fixes: 404 errors for CSS and JS assets in GitHub Pages deployment

### Summary & Motivation

A brief description of the changes in this pull request explaining why these changes are necessary. Please delete this paragraph.

### Checklist for Pull Request - Merge from development into main (production) branch

- [ ] A Label has been added to the Pull Request
- [ ] Automated tests have been added
- [ ] Documentation has been updated automatically or manual
