### PR TITLE
Fix RazorPress docs CSS loading for GitHub Pages deployment

### DIFF
--- a/docs/RazorPress/RazorPress/appsettings.Production.json
+++ b/docs/RazorPress/RazorPress/appsettings.Production.json
@@ -1,0 +1,5 @@
+{
+  "AppConfig": {
+    "BaseHref": "/Saas-Factory/docs/"
+  }
+}

--- a/docs/RazorPress/RazorPress/appsettings.json
+++ b/docs/RazorPress/RazorPress/appsettings.json
@@ -1,0 +1,15 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*",
+  "AppConfig": {
+    "Title": "Razor Press",
+    "LocalBaseUrl": "https://localhost:5002",
+    "PublicBaseUrl": "https://razor-press.web-templates.io",
+    "BaseHref": "/"
+  }
+}


### PR DESCRIPTION
- Add BaseHref configuration for GitHub Pages (/Saas-Factory/docs/)
- Add post-processing to rewrite absolute paths with baseHref prefix
- Update layout and error pages to use AppConfig.BaseHref
- Fix symlink removal in workflow (rm -rf instead of rm -f)
- Add verification step to workflow to check base href in generated HTML

### Summary & Motivation

A brief description of the changes in this pull request explaining why these changes are necessary. Please delete this paragraph.

### Checklist for Pull Request - Merge from development into main (production) branch

- [ ] A Label has been added to the Pull Request
- [ ] Automated tests have been added
- [ ] Documentation has been updated automatically or manual
