### PR TITLE
Fix subdirectory page rendering in RazorPress

### DIFF
--- a/docs/RazorPress/RazorPress/Pages/Page.cshtml
+++ b/docs/RazorPress/RazorPress/Pages/Page.cshtml
@@ -7,8 +7,9 @@
     public List<Page> GetStaticProps(RenderContext ctx)
     {
         var markdown = ctx.Resolve<MarkdownPages>();
-        var pages = markdown.GetVisiblePages();
-        return pages
+        // Get all visible pages using GetAll which returns all pages in all directories
+        var allPages = markdown.GetAll();
+        return allPages
             .Where(page => page.Path != "_pages/index.md")
             .Map(page => new Page { Slug = page.Slug! });
     }


### PR DESCRIPTION
- Changed GetStaticProps to use GetAll() instead of GetVisiblePages()
- Now renders all markdown pages including those in subdirectories
- Fixes 404 errors for /getting-started/quick-start and other nested pages

### Summary & Motivation

A brief description of the changes in this pull request explaining why these changes are necessary. Please delete this paragraph.

### Checklist for Pull Request - Merge from development into main (production) branch

- [ ] A Label has been added to the Pull Request
- [ ] Automated tests have been added
- [ ] Documentation has been updated automatically or manual
