### PR TITLE
Fix Blazor WASM landing page by adding .nojekyll file

### DIFF
--- a/.github/workflows/deploy-combined-github-pages.yml
+++ b/.github/workflows/deploy-combined-github-pages.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: 
       - "main"
-      - "Improve-stability-for-todo-app"
     paths:
       - "Code/Landingpage/**"
       - "docs/RazorPress/**"
@@ -210,6 +209,10 @@ jobs:
           echo "📄 Copying landing page..."
           cp -r Code/Landingpage/Landingpage.Web/publish/wwwroot/* combined-site/
           
+          # Add .nojekyll to prevent GitHub Pages from ignoring _framework directory
+          echo "📝 Adding .nojekyll file..."
+          touch combined-site/.nojekyll
+          
           # Copy documentation to /docs subdirectory
           echo "📚 Copying documentation..."
           mkdir -p combined-site/docs
@@ -228,6 +231,14 @@ jobs:
           echo ""
           echo "📁 Docs directory:"
           ls -lah combined-site/docs/ | head -15
+          echo ""
+          echo "📁 Checking for getting-started directory:"
+          if [ -d "combined-site/docs/getting-started" ]; then
+            echo "✅ getting-started directory exists"
+            ls -la combined-site/docs/getting-started/
+          else
+            echo "❌ getting-started directory NOT found!"
+          fi
           
           # Verify critical files
           echo ""
@@ -235,6 +246,7 @@ jobs:
           [ -f "combined-site/index.html" ] && echo "✅ Landing page index.html" || echo "❌ Missing landing page index.html"
           [ -f "combined-site/docs/index.html" ] && echo "✅ Docs index.html" || echo "❌ Missing docs index.html"
           [ -f "combined-site/docs/css/app.css" ] && echo "✅ Docs CSS" || echo "❌ Missing docs CSS"
+          [ -f "combined-site/docs/getting-started/quick-start.html" ] && echo "✅ quick-start.html" || echo "❌ Missing quick-start.html"
 
       # ========================================
       # Deploy to GitHub Pages


### PR DESCRIPTION
- GitHub Pages ignores directories starting with _ by default
- Added .nojekyll to prevent Jekyll processing
- This allows _framework directory to be served correctly
- Also added verification for getting-started subdirectory

### Summary & Motivation

A brief description of the changes in this pull request explaining why these changes are necessary. Please delete this paragraph.

### Checklist for Pull Request - Merge from development into main (production) branch

- [ ] A Label has been added to the Pull Request
- [ ] Automated tests have been added
- [ ] Documentation has been updated automatically or manual
