### PR TITLE
fix: build Tailwind CSS before .NET build in deployment workflow

### DIFF
--- a/.github/workflows/deploy-combined-github-pages.yml
+++ b/.github/workflows/deploy-combined-github-pages.yml
@@ -118,13 +118,6 @@ jobs:
             exit 1
           fi
 
-      - name: Build .NET project
-        working-directory: docs/RazorPress/RazorPress
-        run: |
-          echo "🔨 Building .NET project..."
-          dotnet build . --configuration Release
-          echo "✅ .NET project built"
-
       - name: Build Tailwind CSS
         working-directory: docs/RazorPress/RazorPress
         run: |
@@ -140,6 +133,13 @@ jobs:
             echo "❌ Error: app.css not generated!"
             exit 1
           fi
+
+      - name: Build .NET project
+        working-directory: docs/RazorPress/RazorPress
+        run: |
+          echo "🔨 Building .NET project..."
+          dotnet build . --configuration Release
+          echo "✅ .NET project built"
 
       - name: Prerender static site
         working-directory: docs/RazorPress/RazorPress


### PR DESCRIPTION
Moved Tailwind CSS build step before .NET build to ensure app.css is available when prerendering the static site. This fixes CSS not being applied on deployed GitHub Pages site.

Also removed duplicate lite-yt-embed.js script include from DocsPage that was causing JavaScript errors.

### Summary & Motivation

A brief description of the changes in this pull request explaining why these changes are necessary. Please delete this paragraph.

### Checklist for Pull Request - Merge from development into main (production) branch

- [ ] A Label has been added to the Pull Request
- [ ] Automated tests have been added
- [ ] Documentation has been updated automatically or manual
