### PR TITLE
fix: Remove invalid @theme directive from Tailwind CSS input

### DIFF
--- a/docs/RazorPress/RazorPress/tailwind.input.css
+++ b/docs/RazorPress/RazorPress/tailwind.input.css
@@ -36,10 +36,13 @@
     ::file-selector-button {
         border-color: hsl(var(--border));
     }
-}
 
-@theme {
-    --default-ring-color: hsl(var(--ring));
+    /* Set default ring color for focus states */
+    *,
+    ::after,
+    ::before {
+        --tw-ring-color: hsl(var(--ring));
+    }
 }
 
 @layer base {


### PR DESCRIPTION
- Removed Tailwind v4 @theme directive incompatible with v3.4.17
- Moved --tw-ring-color variable to @layer base instead
- Fixes CSS parsing errors in browser console
- Resolves docs site styling issues

### Summary & Motivation

A brief description of the changes in this pull request explaining why these changes are necessary. Please delete this paragraph.

### Checklist for Pull Request - Merge from development into main (production) branch

- [ ] A Label has been added to the Pull Request
- [ ] Automated tests have been added
- [ ] Documentation has been updated automatically or manual
