### PR TITLE
Fix GitHub Actions permission to push schema.sql

### DIFF
--- a/.github/workflows/generate-sql-schema-docs.yml
+++ b/.github/workflows/generate-sql-schema-docs.yml
@@ -7,7 +7,10 @@ on:
       - "Code/AppBlueprint/Shared-Modules/AppBlueprint.Infrastructure/Migrations/**"
       - "!**.md"
     branches:
-      - main    
+      - main
+
+permissions:
+  contents: write  # Required to push changes back to the repository
 
 jobs:
   generate-schema:
@@ -19,6 +22,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: true
 
       # Step 2: Install PostgreSQL 17 client tools
       - name: Install PostgreSQL 17 client


### PR DESCRIPTION
- Add contents: write permission to workflow
- Add persist-credentials: true to checkout step
- Allows github-actions[bot] to push schema dump to repository

### Summary & Motivation

A brief description of the changes in this pull request explaining why these changes are necessary. Please delete this paragraph.

### Checklist for Pull Request - Merge from development into main (production) branch

- [ ] A Label has been added to the Pull Request
- [ ] Automated tests have been added
- [ ] Documentation has been updated automatically or manual
