### PR TITLE
feat: enhance security and input validation for Firebase sign-in; add…

### DIFF
--- a/Code/AppBlueprint/AppBlueprint.Tests/AppBlueprint.Tests.csproj
+++ b/Code/AppBlueprint/AppBlueprint.Tests/AppBlueprint.Tests.csproj
@@ -25,6 +25,7 @@
         <PackageReference Include="Aspire.Hosting.Testing" />
         <PackageReference Include="coverlet.collector" />
         <PackageReference Include="Moq" />
+        <PackageReference Include="NSubstitute" />
         <PackageReference Include="TUnit" />
         <PackageReference Include="TUnit.Assertions" />
         <PackageReference Include="NetArchTest.Rules" />
@@ -37,6 +38,7 @@
         <ProjectReference Include="..\Shared-Modules\AppBlueprint.UiKit\AppBlueprint.UiKit.csproj" />
         <ProjectReference Include="..\Shared-Modules\AppBlueprint.Domain\AppBlueprint.Domain.csproj" />
         <ProjectReference Include="..\AppBlueprint.ApiService\AppBlueprint.ApiService.csproj" />
+        <ProjectReference Include="..\AppBlueprint.Web\AppBlueprint.Web.csproj" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Code/AppBlueprint/AppBlueprint.Tests/Web/FirebaseAuthControllerTests.cs
+++ b/Code/AppBlueprint/AppBlueprint.Tests/Web/FirebaseAuthControllerTests.cs
@@ -1,0 +1,92 @@
+using AppBlueprint.Infrastructure.Authentication;
+using AppBlueprint.Web.Controllers;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace AppBlueprint.Tests.Web;
+
+/// <summary>
+/// Tests for the input-validation guard on the Firebase sign-in endpoint (OWASP A03/A07).
+/// Invalid credentials input must be rejected before any call to the Firebase sign-in service,
+/// and must redirect back to the login page with a generic error (no field-level disclosure).
+/// </summary>
+internal sealed class FirebaseAuthControllerTests
+{
+    private const string SignInErrorRedirectPrefix = "/signin/firebase?error=";
+
+    private static (FirebaseAuthController Controller, IFirebaseSignInService SignInService) CreateController()
+    {
+        IFirebaseSignInService signInService = Substitute.For<IFirebaseSignInService>();
+        ILogger<FirebaseAuthController> logger = Substitute.For<ILogger<FirebaseAuthController>>();
+
+        var controller = new FirebaseAuthController(signInService, logger);
+        return (controller, signInService);
+    }
+
+    [Test]
+    [Arguments("", "somePassword")]
+    [Arguments("   ", "somePassword")]
+    [Arguments("user@example.com", "")]
+    [Arguments("user@example.com", "   ")]
+    public async Task SignIn_WithMissingCredentials_RedirectsWithoutCallingFirebase(string email, string password)
+    {
+        (FirebaseAuthController controller, IFirebaseSignInService signInService) = CreateController();
+        var request = new FirebaseSignInFormRequest { Email = email, Password = password };
+
+        IActionResult result = await controller.SignIn(request);
+
+        var redirect = result as RedirectResult;
+        await Assert.That(redirect).IsNotNull();
+        await Assert.That(redirect!.Url).StartsWith(SignInErrorRedirectPrefix);
+        await signInService.DidNotReceiveWithAnyArgs().SignInAsync(default!, default!);
+    }
+
+    [Test]
+    public async Task SignIn_WithOversizedEmail_RedirectsWithoutCallingFirebase()
+    {
+        (FirebaseAuthController controller, IFirebaseSignInService signInService) = CreateController();
+        string oversizedEmail = new string('a', 250) + "@example.com"; // exceeds RFC 5321 limit of 254
+        var request = new FirebaseSignInFormRequest { Email = oversizedEmail, Password = "somePassword" };
+
+        IActionResult result = await controller.SignIn(request);
+
+        var redirect = result as RedirectResult;
+        await Assert.That(redirect).IsNotNull();
+        await Assert.That(redirect!.Url).StartsWith(SignInErrorRedirectPrefix);
+        await signInService.DidNotReceiveWithAnyArgs().SignInAsync(default!, default!);
+    }
+
+    [Test]
+    public async Task SignIn_WithOversizedPassword_RedirectsWithoutCallingFirebase()
+    {
+        (FirebaseAuthController controller, IFirebaseSignInService signInService) = CreateController();
+        var request = new FirebaseSignInFormRequest
+        {
+            Email = "user@example.com",
+            Password = new string('p', 129) // exceeds Firebase's 128-character maximum
+        };
+
+        IActionResult result = await controller.SignIn(request);
+
+        var redirect = result as RedirectResult;
+        await Assert.That(redirect).IsNotNull();
+        await Assert.That(redirect!.Url).StartsWith(SignInErrorRedirectPrefix);
+        await signInService.DidNotReceiveWithAnyArgs().SignInAsync(default!, default!);
+    }
+
+    [Test]
+    public async Task SignIn_WithRejectedCredentials_RedirectsWithError()
+    {
+        (FirebaseAuthController controller, IFirebaseSignInService signInService) = CreateController();
+        signInService.SignInAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new FirebaseSignInResult { IsSuccess = false, Error = "INVALID_LOGIN_CREDENTIALS" });
+        var request = new FirebaseSignInFormRequest { Email = "user@example.com", Password = "wrongPassword" };
+
+        IActionResult result = await controller.SignIn(request);
+
+        var redirect = result as RedirectResult;
+        await Assert.That(redirect).IsNotNull();
+        await Assert.That(redirect!.Url).StartsWith(SignInErrorRedirectPrefix);
+    }
+}

--- a/Code/AppBlueprint/AppBlueprint.Web/Controllers/FirebaseAuthController.cs
+++ b/Code/AppBlueprint/AppBlueprint.Web/Controllers/FirebaseAuthController.cs
@@ -3,6 +3,7 @@ using AppBlueprint.Infrastructure.Authentication;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
 
 namespace AppBlueprint.Web.Controllers;
 
@@ -18,6 +19,11 @@ namespace AppBlueprint.Web.Controllers;
 public sealed class FirebaseAuthController : ControllerBase
 {
     private const string FirebaseCookieScheme = "Firebase.Cookie";
+
+    // SECURITY (OWASP A03): bound credential input before it reaches the Firebase HTTP call.
+    // RFC 5321 caps e-mail addresses at 254 characters; Firebase rejects passwords over 128.
+    private const int MaxEmailLength = 254;
+    private const int MaxPasswordLength = 128;
 
     private readonly IFirebaseSignInService _firebaseSignIn;
     private readonly ILogger<FirebaseAuthController> _logger;
@@ -39,9 +45,21 @@ public sealed class FirebaseAuthController : ControllerBase
     /// </summary>
     [HttpPost("firebase-signin")]
     [Consumes("application/x-www-form-urlencoded")]
+    [EnableRateLimiting("auth-signin")]
     public async Task<IActionResult> SignIn([FromForm] FirebaseSignInFormRequest request)
     {
         ArgumentNullException.ThrowIfNull(request);
+
+        // SECURITY (OWASP A03/A07): validate input manually (not via DataAnnotations) so the
+        // browser form flow keeps its redirect-with-error UX instead of an automatic JSON 400.
+        // Use a generic error message to avoid disclosing which field was rejected.
+        if (string.IsNullOrWhiteSpace(request.Email) || string.IsNullOrWhiteSpace(request.Password)
+            || request.Email.Length > MaxEmailLength || request.Password.Length > MaxPasswordLength)
+        {
+            _logger.LogWarning("Firebase sign-in rejected: invalid form input");
+            string encodedValidationError = Uri.EscapeDataString("Login failed. Please check your credentials.");
+            return Redirect($"/signin/firebase?error={encodedValidationError}");
+        }
 
         FirebaseSignInResult result = await _firebaseSignIn.SignInAsync(request.Email, request.Password);
 

--- a/Code/AppBlueprint/AppBlueprint.Web/Program.cs
+++ b/Code/AppBlueprint/AppBlueprint.Web/Program.cs
@@ -11,6 +11,8 @@ using AppBlueprint.UiKit.Models;
 using AppBlueprint.Web.Components;
 using Blazored.LocalStorage;
 using Microsoft.AspNetCore.HttpOverrides;
+using Microsoft.AspNetCore.RateLimiting;
+using System.Threading.RateLimiting;
 using Microsoft.Kiota.Abstractions;
 using Microsoft.Kiota.Abstractions.Authentication;
 using Microsoft.Kiota.Http.HttpClientLibrary;
@@ -142,6 +144,26 @@ builder.Services.AddRazorComponents().AddInteractiveServerComponents();
 
 // Add API controllers for Web-specific endpoints (e.g., FirebaseConfigController)
 builder.Services.AddControllers();
+
+// Rate limiting (OWASP A07 - Identification and Authentication Failures).
+// The Firebase sign-in endpoint accepts credentials and must be protected against
+// brute-force/credential-stuffing. Partition per client IP (forwarded headers are
+// configured above, so RemoteIpAddress reflects the real client behind Railway).
+builder.Services.AddRateLimiter(options =>
+{
+    options.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
+    options.AddPolicy("auth-signin", httpContext =>
+    {
+        string partitionKey = httpContext.Connection.RemoteIpAddress?.ToString() ?? "anonymous";
+
+        return RateLimitPartition.GetFixedWindowLimiter(partitionKey, _ => new FixedWindowRateLimiterOptions
+        {
+            PermitLimit = 5,
+            Window = TimeSpan.FromMinutes(1),
+            QueueLimit = 0
+        });
+    });
+});
 
 // Add minimal API versioning to register the 'apiVersion' route constraint
 // This allows controllers from referenced assemblies to use versioned routes without errors
@@ -363,6 +385,9 @@ app.UseCookiePolicy();
 // Add authentication and authorization middleware for Logto
 app.UseAuthentication();
 app.UseAuthorization();
+
+// Rate limiting - enforces the "auth-signin" policy on credential endpoints
+app.UseRateLimiter();
 
 // ✅ Add admin IP whitelist (blocks non-whitelisted IPs from admin routes)
 // Only enabled in production - disabled in development to avoid local access issues

--- a/Code/DeploymentManager/DeploymentManager.ApiService/Api/Controllers/AppController/AppController.cs
+++ b/Code/DeploymentManager/DeploymentManager.ApiService/Api/Controllers/AppController/AppController.cs
@@ -1,7 +1,10 @@
+using AppBlueprint.Application.Constants;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace DeploymentManager.ApiService.Api.Controllers.AppController;
 
+[Authorize(Roles = Roles.DeploymentManagerAdmin)]
 [Route("api/[controller]")]
 [ApiController]
 public class AppController : ControllerBase

--- a/Code/DeploymentManager/DeploymentManager.ApiService/Api/Controllers/Azure/AzureBlobStorageController.cs
+++ b/Code/DeploymentManager/DeploymentManager.ApiService/Api/Controllers/Azure/AzureBlobStorageController.cs
@@ -1,7 +1,10 @@
+using AppBlueprint.Application.Constants;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace DeploymentManager.ApiService.Api.Controllers.Azure;
 
+[Authorize(Roles = Roles.DeploymentManagerAdmin)]
 [Route("api/[controller]")]
 [ApiController]
 public class AzureBlobStorageController : ControllerBase

--- a/Code/DeploymentManager/DeploymentManager.ApiService/Api/Controllers/Azure/AzureRegionController.cs
+++ b/Code/DeploymentManager/DeploymentManager.ApiService/Api/Controllers/Azure/AzureRegionController.cs
@@ -1,7 +1,10 @@
+using AppBlueprint.Application.Constants;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace DeploymentManager.ApiService.Api.Controllers.Azure;
 
+[Authorize(Roles = Roles.DeploymentManagerAdmin)]
 [Route("api/[controller]")]
 [ApiController]
 public class AzureRegionController : ControllerBase

--- a/Code/DeploymentManager/DeploymentManager.ApiService/Api/Controllers/Azure/AzureSubscriptionController.cs
+++ b/Code/DeploymentManager/DeploymentManager.ApiService/Api/Controllers/Azure/AzureSubscriptionController.cs
@@ -1,7 +1,10 @@
+using AppBlueprint.Application.Constants;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace DeploymentManager.ApiService.Api.Controllers.Azure;
 
+[Authorize(Roles = Roles.DeploymentManagerAdmin)]
 [Route("api/[controller]")]
 [ApiController]
 public class AzureSubscriptionController : ControllerBase

--- a/Code/DeploymentManager/DeploymentManager.ApiService/Api/Controllers/Customer/CustomerController.cs
+++ b/Code/DeploymentManager/DeploymentManager.ApiService/Api/Controllers/Customer/CustomerController.cs
@@ -1,7 +1,10 @@
+using AppBlueprint.Application.Constants;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace DeploymentManager.ApiService.Api.Controllers.Customer;
 
+[Authorize(Roles = Roles.DeploymentManagerAdmin)]
 [Route("api/[controller]")]
 [ApiController]
 public class CustomerController : ControllerBase

--- a/Code/DeploymentManager/DeploymentManager.ApiService/Api/Controllers/Deployment/CustomerEnvironmentController.cs
+++ b/Code/DeploymentManager/DeploymentManager.ApiService/Api/Controllers/Deployment/CustomerEnvironmentController.cs
@@ -1,7 +1,10 @@
+using AppBlueprint.Application.Constants;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace DeploymentManager.ApiService.Api.Controllers.Deployment;
 
+[Authorize(Roles = Roles.DeploymentManagerAdmin)]
 [Route("api/[controller]")]
 [ApiController]
 public class CustomerEnvironmentController : ControllerBase

--- a/Code/DeploymentManager/DeploymentManager.ApiService/Api/Controllers/Deployment/DeploymentController.cs
+++ b/Code/DeploymentManager/DeploymentManager.ApiService/Api/Controllers/Deployment/DeploymentController.cs
@@ -1,8 +1,11 @@
+using AppBlueprint.Application.Constants;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace DeploymentManager.ApiService.Api.Controllers.Deployment;
 
 //  /api/deployment
+[Authorize(Roles = Roles.DeploymentManagerAdmin)]
 [ApiController]
 [Route("[controller]")]
 public class

--- a/Code/DeploymentManager/DeploymentManager.ApiService/Api/Controllers/Pulumi/ProjectController.cs
+++ b/Code/DeploymentManager/DeploymentManager.ApiService/Api/Controllers/Pulumi/ProjectController.cs
@@ -1,6 +1,8 @@
+using AppBlueprint.Application.Constants;
 using DeploymentManager.ApiService.Domain.DTOs.Project;
 using DeploymentManager.ApiService.Domain.Entities;
 using DeploymentManager.ApiService.Domain.Interfaces;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace DeploymentManager.ApiService.Api.Controllers.Pulumi;
@@ -10,6 +12,7 @@ public class ResponseDto
     public string Name { get; set; }
 }
 
+[Authorize(Roles = Roles.DeploymentManagerAdmin)]
 [ApiController]
 [Route("[controller]")]
 public class ProjectController : Controller

--- a/Code/DeploymentManager/DeploymentManager.ApiService/DeploymentManager.ApiService.csproj
+++ b/Code/DeploymentManager/DeploymentManager.ApiService/DeploymentManager.ApiService.csproj
@@ -13,6 +13,9 @@
         <ProjectReference Include="..\..\AppBlueprint\AppBlueprint.ServiceDefaults\AppBlueprint.ServiceDefaults.csproj" />
         <ProjectReference Include="..\..\AppBlueprint\Shared-Modules\Infrastructure\AppBlueprint.Infrastructure\AppBlueprint.Infrastructure.csproj" />
     <ProjectReference Include="..\..\AppBlueprint\Shared-Modules\AppBlueprint.SharedKernel\AppBlueprint.SharedKernel.csproj" />
+        <!-- Referenced for AddJwtAuthentication only; its controllers are removed from
+             application part discovery in Program.cs so they are not exposed by this API. -->
+        <ProjectReference Include="..\..\AppBlueprint\Shared-Modules\AppBlueprint.Presentation.ApiModule\AppBlueprint.Presentation.ApiModule.csproj" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Code/DeploymentManager/DeploymentManager.ApiService/Program.cs
+++ b/Code/DeploymentManager/DeploymentManager.ApiService/Program.cs
@@ -1,3 +1,4 @@
+using AppBlueprint.Presentation.ApiModule.Extensions;
 using AppBlueprint.ServiceDefaults;
 using DeploymentManager.ApiService;
 using DeploymentManager.ApiService.Application.Services;
@@ -5,6 +6,7 @@ using DeploymentManager.ApiService.Domain.Interfaces;
 using DeploymentManager.ApiService.Infrastructure.Persistence.Data.Context;
 using DeploymentManager.ApiService.Infrastructure.Persistence.Data.UnitOfWork;
 using DeploymentManager.ApiService.Infrastructure.Services;
+using Microsoft.AspNetCore.Mvc.ApplicationParts;
 using Microsoft.EntityFrameworkCore;
 using static DeploymentManager.ApiService.Infrastructure.Persistence.Data.Context.PostgresConnectionStringHelper;
 
@@ -13,7 +15,24 @@ WebApplicationBuilder? builder = WebApplication.CreateBuilder(args);
 builder.AddServiceDefaults();
 
 builder.Services.AddProblemDetails();
-builder.Services.AddControllers();
+builder.Services.AddControllers()
+    .ConfigureApplicationPartManager(partManager =>
+    {
+        // AppBlueprint.Presentation.ApiModule is referenced only for its JWT authentication
+        // extensions. Remove it from controller discovery so AppBlueprint's own controllers
+        // (users, tenants, files, ...) are not exposed by the DeploymentManager API.
+        ApplicationPart? appBlueprintPart = partManager.ApplicationParts
+            .FirstOrDefault(part => part.Name == "AppBlueprint.Presentation.ApiModule");
+        if (appBlueprintPart is not null)
+        {
+            partManager.ApplicationParts.Remove(appBlueprintPart);
+        }
+    });
+
+// SECURITY (OWASP A01): the DeploymentManager API manages deployed SaaS apps across all
+// customers. Reuse AppBlueprint's JWT bearer authentication (Logto); every controller is
+// additionally gated to the DeploymentManagerAdmin role via [Authorize] attributes.
+builder.Services.AddJwtAuthentication(builder.Configuration, builder.Environment);
 
 string connectionString = Normalize(
     builder.Configuration.GetConnectionString("DefaultConnection")
@@ -38,6 +57,14 @@ using (IServiceScope scope = app.Services.CreateScope())
 }
 
 app.UseExceptionHandler();
+
+app.UseAuthentication();
+app.UseAuthorization();
+
+// Health checks remain anonymous (mapped by MapDefaultEndpoints); all controllers
+// require the DeploymentManagerAdmin role via their [Authorize] attributes.
+app.MapControllers();
+
 app.MapDefaultEndpoints();
 
 string[]? summaries = new[]

--- a/Code/DeploymentManager/DeploymentManager.Tests/ControllerAuthorizationTests.cs
+++ b/Code/DeploymentManager/DeploymentManager.Tests/ControllerAuthorizationTests.cs
@@ -1,0 +1,74 @@
+using System.Reflection;
+using AppBlueprint.Application.Constants;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace DeploymentManager.Tests;
+
+/// <summary>
+/// Security regression tests (OWASP A01 - Broken Access Control).
+/// The DeploymentManager API manages deployed SaaS apps across all customers,
+/// so every controller must require the DeploymentManagerAdmin role.
+/// </summary>
+internal sealed class ControllerAuthorizationTests
+{
+    private static List<Type> GetApiControllers()
+    {
+        Assembly apiAssembly = typeof(global::DeploymentManager.ApiService.Api.Controllers.Pulumi.ProjectController).Assembly;
+
+        return apiAssembly.GetTypes()
+            .Where(type => typeof(ControllerBase).IsAssignableFrom(type)
+                           && !type.IsAbstract)
+            .ToList();
+    }
+
+    [Test]
+    public async Task AllControllers_MustRequireDeploymentManagerAdminRole()
+    {
+        List<Type> controllers = GetApiControllers();
+
+        await Assert.That(controllers.Count).IsGreaterThan(0);
+
+        List<string> unprotected = new();
+
+        foreach (Type controller in controllers)
+        {
+            AuthorizeAttribute? authorize = controller.GetCustomAttributes<AuthorizeAttribute>(inherit: true)
+                .FirstOrDefault();
+
+            if (authorize is null || authorize.Roles is null
+                || !authorize.Roles.Contains(Roles.DeploymentManagerAdmin, StringComparison.Ordinal))
+            {
+                unprotected.Add(controller.FullName ?? controller.Name);
+            }
+        }
+
+        string unprotectedControllers = string.Join(", ", unprotected);
+        await Assert.That(unprotectedControllers).IsEmpty();
+    }
+
+    [Test]
+    public async Task NoControllerAction_MayAllowAnonymousAccess()
+    {
+        List<string> anonymousActions = new();
+
+        foreach (Type controller in GetApiControllers())
+        {
+            if (controller.GetCustomAttributes<AllowAnonymousAttribute>(inherit: true).Any())
+            {
+                anonymousActions.Add(controller.FullName ?? controller.Name);
+            }
+
+            foreach (MethodInfo action in controller.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly))
+            {
+                if (action.GetCustomAttributes<AllowAnonymousAttribute>(inherit: true).Any())
+                {
+                    anonymousActions.Add($"{controller.FullName}.{action.Name}");
+                }
+            }
+        }
+
+        string anonymousEndpoints = string.Join(", ", anonymousActions);
+        await Assert.That(anonymousEndpoints).IsEmpty();
+    }
+}

--- a/Code/DeploymentManager/DeploymentManager.Tests/DeploymentManager.Tests.csproj
+++ b/Code/DeploymentManager/DeploymentManager.Tests/DeploymentManager.Tests.csproj
@@ -6,23 +6,23 @@
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
         <IsTestProject>true</IsTestProject>
+        <!-- TUnit runs on Microsoft.Testing.Platform, which requires an executable test project -->
+        <OutputType>Exe</OutputType>
     </PropertyGroup>
 
     <ItemGroup>
         <PackageReference Include="Aspire.Hosting.Testing"/>
-        <PackageReference Include="coverlet.collector"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk"/>
-        <PackageReference Include="xunit"/>
-        <PackageReference Include="xunit.runner.visualstudio"/>
+        <PackageReference Include="TUnit"/>
+        <PackageReference Include="TUnit.Assertions"/>
     </ItemGroup>
 
     <ItemGroup>
         <ProjectReference Include="..\DeploymentManager.AppHost\DeploymentManager.AppHost.csproj"/>
+        <ProjectReference Include="..\DeploymentManager.ApiService\DeploymentManager.ApiService.csproj"/>
     </ItemGroup>
 
     <ItemGroup>
         <Using Include="Aspire.Hosting.Testing"/>
-        <Using Include="Xunit"/>
     </ItemGroup>
 
 </Project>

--- a/Code/DeploymentManager/DeploymentManager.Tests/WebTests.cs
+++ b/Code/DeploymentManager/DeploymentManager.Tests/WebTests.cs
@@ -4,9 +4,9 @@ using Projects;
 
 namespace DeploymentManager.Tests;
 
-public class WebTests
+internal sealed class WebTests
 {
-    [Fact]
+    [Test]
     public async Task GetWebResourceRootReturnsOkStatusCode()
     {
         // Arrange
@@ -17,9 +17,9 @@ public class WebTests
 
         // Act
         HttpClient? httpClient = app.CreateHttpClient("webfrontend");
-        HttpResponseMessage? response = await httpClient.GetAsync("/");
+        HttpResponseMessage? response = await httpClient.GetAsync(new Uri("/", UriKind.Relative));
 
         // Assert
-        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
     }
 }

--- a/Code/DeploymentManager/DeploymentManager.Web/Components/Pages/Error.razor
+++ b/Code/DeploymentManager/DeploymentManager.Web/Components/Pages/Error.razor
@@ -1,5 +1,7 @@
 ﻿@page "/Error"
 @using System.Diagnostics
+@* The error page must render for unauthenticated users too. *@
+@attribute [AllowAnonymous]
 
 <PageTitle>Error</PageTitle>
 

--- a/Code/DeploymentManager/DeploymentManager.Web/Components/Pages/_Imports.razor
+++ b/Code/DeploymentManager/DeploymentManager.Web/Components/Pages/_Imports.razor
@@ -1,0 +1,9 @@
+@using Microsoft.AspNetCore.Authorization
+@using AppBlueprint.Application.Constants
+@*
+    SECURITY (OWASP A01): the Deployment Manager portal manages deployed SaaS apps across
+    all customers, so every page requires the DeploymentManagerAdmin role by default.
+    Pages that must be reachable without it (e.g. the error page) opt out explicitly
+    with [AllowAnonymous].
+*@
+@attribute [Authorize(Roles = Roles.DeploymentManagerAdmin)]

--- a/Code/DeploymentManager/DeploymentManager.Web/Components/Routes.razor
+++ b/Code/DeploymentManager/DeploymentManager.Web/Components/Routes.razor
@@ -1,7 +1,25 @@
-﻿@using DeploymentManager.Web.Components.Layout
+@using DeploymentManager.Web.Components.Layout
+@using Microsoft.AspNetCore.Components.Authorization
+@inject NavigationManager NavigationManager
 <Router AppAssembly="@typeof(Program).Assembly">
     <Found Context="routeData">
-        <RouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)"/>
+        <AuthorizeRouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)">
+            <NotAuthorized Context="authContext">
+                @if (authContext.User.Identity?.IsAuthenticated != true)
+                {
+                    @RedirectToSignIn()
+                }
+                else
+                {
+                    <LayoutView Layout="@typeof(MainLayout)">
+                        <p>You are not authorized to access the Deployment Manager. A DeploymentManagerAdmin role is required.</p>
+                    </LayoutView>
+                }
+            </NotAuthorized>
+            <Authorizing>
+                <p>Checking access...</p>
+            </Authorizing>
+        </AuthorizeRouteView>
         <FocusOnNavigate RouteData="@routeData" Selector="h1"/>
     </Found>
     <NotFound>
@@ -10,3 +28,12 @@
         </LayoutView>
     </NotFound>
 </Router>
+
+@code {
+
+    private RenderFragment RedirectToSignIn() => _ =>
+    {
+        NavigationManager.NavigateTo("/auth/signin", forceLoad: true);
+    };
+
+}

--- a/Code/DeploymentManager/DeploymentManager.Web/Program.cs
+++ b/Code/DeploymentManager/DeploymentManager.Web/Program.cs
@@ -89,9 +89,11 @@ app.UseOutputCache();
 
 app.MapAuthenticationEndpoints(builder.Configuration);
 
+// SECURITY (OWASP A01): no .AllowAnonymous() here - pages carry
+// [Authorize(Roles = Roles.DeploymentManagerAdmin)] via Components/Pages/_Imports.razor,
+// and AuthorizeRouteView in Routes.razor enforces it during interactive navigation.
 app.MapRazorComponents<App>()
-    .AddInteractiveServerRenderMode()
-    .AllowAnonymous();
+    .AddInteractiveServerRenderMode();
 
 app.MapDefaultEndpoints();
 


### PR DESCRIPTION
… rate limiting and authorization checks

### Summary & Motivation

A brief description of the changes in this pull request explaining why these changes are necessary. Please delete this paragraph.

### Checklist for Pull Request - Merge from development into main (production) branch

- [ ] A Label has been added to the Pull Request
- [ ] Automated tests have been added
- [ ] Documentation has been updated automatically or manual


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strengthens authentication: validates Firebase sign-in input, adds per‑IP rate limiting, and enforces admin‑only access across Deployment Manager APIs and pages. Reduces brute‑force risk and blocks unauthorized access.

- **New Features**
  - Firebase sign-in: server-side validation (email ≤254, password ≤128) with generic error redirect; `auth-signin` fixed-window rate limiter (5/min/IP).
  - DeploymentManager API: JWT auth via AddJwtAuthentication; all controllers require `Roles.DeploymentManagerAdmin`; removed `AppBlueprint.Presentation.ApiModule` from controller discovery.
  - DeploymentManager Web: global `[Authorize(Roles = Roles.DeploymentManagerAdmin)]`, protected routes with `AuthorizeRouteView`, `/Error` allows anonymous; unauthenticated users redirect to `/auth/signin`.
  - Tests: added authorization coverage for all API controllers and validation/routing tests for Firebase sign-in.

- **Dependencies**
  - Added `NSubstitute` to tests; switched DeploymentManager tests to `TUnit` and `TUnit.Assertions`; removed `xunit` and `Microsoft.NET.Test.Sdk`.

<sup>Written for commit 0dd103139afe6258772b107c910adbcc2d4fd29a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/saas-factory-labs/Saas-Factory/pull/243?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Implemented rate limiting on the sign-in endpoint to prevent brute-force attacks
  * Enforced admin authorization requirements across deployment management features
  * Added server-side credential validation with improved error messaging

* **User Experience**
  * Error pages now accessible to all users
  * Unauthenticated users are redirected to the sign-in page with clear messaging

<!-- end of auto-generated comment: release notes by coderabbit.ai -->