### PR TITLE
feat: Add .dockerignore file and update package versions for consiste…

### DIFF
--- a/Code/.dockerignore
+++ b/Code/.dockerignore
@@ -1,0 +1,92 @@
+# Build context: Code/
+# Used by all Dockerfiles with build context = Code/
+
+# Build outputs
+**/bin
+**/obj
+**/out
+**/*.dll
+**/*.exe
+**/*.pdb
+
+# Environment and secrets
+**/.env
+**/.env.*
+**/*.local
+**/appsettings.*.json
+!**/appsettings.json
+**/launchSettings.json
+**/secrets.json
+**/secrets.dev.yaml
+**/values.dev.yaml
+doppler.yaml
+
+# Certificates and keys
+**/*.pfx
+**/*.p12
+**/*.key
+**/*.pem
+**/*.cer
+**/*.crt
+**/*.cert
+
+# Version control
+**/.git
+**/.gitignore
+**/.gitattributes
+**/.github
+
+# IDE and editor files
+**/.vs
+**/.vscode
+**/.idea
+**/*.swp
+**/*.swo
+**/*~
+**/.DS_Store
+**/*.*proj.user
+
+# Docker files
+**/Dockerfile*
+**/docker-compose*
+**/compose*
+**/.dockerignore
+
+# Dependencies
+**/node_modules
+**/npm-debug.log
+
+# Test results
+**/TestResults
+**/coverage
+**/*.coverage
+**/*.coveragexml
+
+# Database files
+**/*.db
+**/*.sqlite
+**/*.mdf
+**/*.ldf
+
+# Logs
+**/*.log
+**/logs/
+
+# Cloud configs
+**/.azure
+**/*.publishsettings
+azure.yaml
+
+# Kubernetes
+**/charts
+**/azds.yaml
+
+# Infrastructure / IaC (not needed at runtime)
+**/*.bicep
+**/Diagrams/
+
+# Temporary files
+**/tmp/
+**/temp/
+**/*.tmp
+**/*.bak

--- a/Code/AppBlueprint/Directory.Packages.props
+++ b/Code/AppBlueprint/Directory.Packages.props
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <!-- Central Package Management -->
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <!-- ═══════════ TESTING & QUALITY-ASSURANCE ═════════════════════════ -->
   <ItemGroup>
@@ -55,35 +56,35 @@
     <!-- Microsoft.Extensions 10.x -->
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.CommandLine" Version="10.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.CommandLine" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Diagnostics" Version="10.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.7.0" />
     <PackageVersion Include="Microsoft.Extensions.Http.Resiliency" Version="10.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Configuration" Version="10.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="10.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.EventLog" Version="10.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.EventSource" Version="10.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Primitives" Version="10.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Configuration" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.EventLog" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.EventSource" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Primitives" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.7.0" />
     <PackageVersion Include="Microsoft.Extensions.Compliance.Abstractions" Version="10.7.0" />
     <PackageVersion Include="Microsoft.Extensions.Compliance.Redaction" Version="10.7.0" />
     <!-- Cloud / infrastructure SDKs -->
-    <PackageVersion Include="AWSSDK.Core" Version="3.7.400.54" />
+    <PackageVersion Include="AWSSDK.Core" Version="4.0.9" />
     <PackageVersion Include="AWSSDK.S3" Version="4.0.24.3" />
     <PackageVersion Include="AWSSDK.SecurityToken" Version="3.7.401.25" />
     <PackageVersion Include="Azure.Security.KeyVault.Secrets" Version="4.8.0" />
@@ -92,22 +93,22 @@
     <PackageVersion Include="Pulumi.AzureNative" Version="3.10.0" />
     <PackageVersion Include="Pulumi.Cloudflare" Version="5.49.0" />
     <PackageVersion Include="Scrutor" Version="5.0.1" />
-    <PackageVersion Include="System.Configuration.ConfigurationManager" Version="10.0.0" />
-    <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="10.0.0" />
+    <PackageVersion Include="System.Configuration.ConfigurationManager" Version="10.0.9" />
+    <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="10.0.9" />
     <PackageVersion Include="Yarp.ReverseProxy" Version="2.3.0" />
     <PackageVersion Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.0" />
   </ItemGroup>
   <!-- ═══════════ ENTITY FRAMEWORK & DATABASE ═════════════════════════ -->
   <ItemGroup>
     <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Abstractions" Version="10.0.1" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Analyzers" Version="10.0.1" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Abstractions" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Analyzers" Version="10.0.9" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.9">
       <IncludeAssets>runtime;build;native;contentfiles;analyzers;buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageVersion>
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.1" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.9" />
     <PackageVersion Include="Npgsql" Version="10.0.3" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.2" />
     <PackageVersion Include="MongoDB.Driver.Core" Version="2.30.0" />
@@ -144,30 +145,30 @@
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.9" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.Cookies" Version="2.3.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Authorization" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.AspNetCore.DataProtection" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.DataProtection.Abstractions" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.DataProtection" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.AspNetCore.DataProtection.Abstractions" Version="10.0.9" />
     <PackageVersion Include="Microsoft.IdentityModel.Tokens" Version="8.19.1" />
     <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.19.1" />
   </ItemGroup>
   <!-- ═══════════ SERIALISATION & DATA ════════════════════════════════ -->
   <ItemGroup>
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageVersion Include="System.Text.Json" Version="10.0.0" />
+    <PackageVersion Include="System.Text.Json" Version="10.0.9" />
   </ItemGroup>
   <!-- ═══════════ UI & FRONT-END ══════════════════════════════════════ -->
   <ItemGroup>
     <PackageVersion Include="Blazored.LocalStorage" Version="4.5.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components" Version="10.0.9" />
     <PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.JSInterop" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.JSInterop" Version="10.0.9" />
     <PackageVersion Include="Microsoft.TypeScript.MSBuild" Version="6.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime;build;native;contentfiles;analyzers;buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="Z.Blazor.Diagrams" Version="3.0.3" />
-    <PackageVersion Include="Z.Blazor.Diagrams.Core" Version="3.0.3" />
-    <PackageVersion Include="Z.Blazor.Diagrams.Algorithms" Version="3.0.3" />
+    <PackageVersion Include="Z.Blazor.Diagrams" Version="3.0.4.1" />
+    <PackageVersion Include="Z.Blazor.Diagrams.Core" Version="3.0.4.1" />
+    <PackageVersion Include="Z.Blazor.Diagrams.Algorithms" Version="3.0.4.1" />
   </ItemGroup>
   <!-- ═══════════ GRAPHQL & API CLIENTS ═══════════════════════════════ -->
   <ItemGroup>
@@ -196,7 +197,7 @@
   <ItemGroup>
     <!-- OpenTelemetry (Updated to 1.11.1+ to fix security vulnerability) -->
     <PackageVersion Include="OpenTelemetry" Version="1.16.0" />
-    <PackageVersion Include="OpenTelemetry.Api" Version="1.11.1" />
+    <PackageVersion Include="OpenTelemetry.Api" Version="1.16.0" />
     <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.16.0" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.16.0" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.16.0" />

--- a/Code/DeploymentManager/DeploymentManager.Web/Dockerfile
+++ b/Code/DeploymentManager/DeploymentManager.Web/Dockerfile
@@ -10,6 +10,14 @@ FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
 
+# Install Node.js for TypeScript compilation (required by AppBlueprint.UiKit → Microsoft.TypeScript.MSBuild)
+RUN apt-get update && \
+    apt-get install -y curl && \
+    curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
+    apt-get install -y nodejs && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
 # Package management
 COPY DeploymentManager/Directory.Packages.props DeploymentManager/
 COPY AppBlueprint/Directory.Packages.props AppBlueprint/
@@ -47,6 +55,12 @@ COPY AppBlueprint/ AppBlueprint/
 WORKDIR /src/DeploymentManager/DeploymentManager.Web
 RUN dotnet build "DeploymentManager.Web.csproj" -c "$BUILD_CONFIGURATION" -o /app/build
 
+# Empty plugins dir — always present so the final stage COPY never fails.
+# To inject real admin portal DLLs at build time, use BuildKit's --build-context flag:
+#   docker build --build-context plugin-src=./plugins <context>
+# and add a RUN --mount=from=plugin-src step to populate /app/plugins before publish.
+RUN mkdir -p /app/plugins
+
 FROM build AS publish
 ARG BUILD_CONFIGURATION=Release
 RUN dotnet publish "DeploymentManager.Web.csproj" -c "$BUILD_CONFIGURATION" -o /app/publish /p:UseAppHost=false
@@ -57,9 +71,8 @@ WORKDIR /app
 
 COPY --from=publish --chown=$APP_UID:$APP_UID /app/publish .
 
-# Admin portal plugin modules: CI pipeline (Scripts/download-admin-plugins.ps1) populates
-# this folder before docker build; it is always present (empty when no plugins configured).
-COPY --chown=$APP_UID:$APP_UID plugins/ ./plugins/
+# Copy plugins dir from build stage (empty on Railway/git builds; contains DLLs for CI builds).
+COPY --from=build --chown=$APP_UID:$APP_UID /app/plugins ./plugins/
 ENV AdminPortal__PluginsPath=/app/plugins
 
 ENV ASPNETCORE_URLS=http://+:8080 \

--- a/Code/DeploymentManager/Directory.Packages.props
+++ b/Code/DeploymentManager/Directory.Packages.props
@@ -2,6 +2,7 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
     <NoWarn>$(NoWarn);NU1507</NoWarn>
   </PropertyGroup>
   <!-- Consolidated and cleaned package versions -->
@@ -12,46 +13,46 @@
     <PackageVersion Include="Microsoft.Kiota.Serialization.Json" Version="1.17.2" />
     <PackageVersion Include="Microsoft.Kiota.Serialization.Multipart" Version="1.17.2" />
     <PackageVersion Include="Microsoft.Kiota.Serialization.Text" Version="1.17.2" />
-    <PackageVersion Include="Resend" Version="0.1.1" />
+    <PackageVersion Include="Resend" Version="0.5.1" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.7.0" />
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.7.0" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Compliance.Abstractions" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Compliance.Redaction" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Compliance.Abstractions" Version="10.7.0" />
+    <PackageVersion Include="Microsoft.Extensions.Compliance.Redaction" Version="10.7.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.9" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.9" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.9" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.9">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageVersion>
-    <PackageVersion Include="Npgsql" Version="10.0.0" />
+    <PackageVersion Include="Npgsql" Version="10.0.3" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.2" />
     <PackageVersion Include="AspNetCore.HealthChecks.NpgSql" Version="9.0.0" />
     <PackageVersion Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.22.0" />
     <PackageVersion Include="Microsoft.IdentityModel.Tokens" Version="8.9.0" />
     <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.9.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Authorization" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.DataProtection" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.DataProtection.Abstractions" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Core" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.JSInterop" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authorization" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.AspNetCore.DataProtection" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.AspNetCore.DataProtection.Abstractions" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Core" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.JSInterop" Version="10.0.9" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.4.0" />
     <PackageVersion Include="OpenTelemetry" Version="1.16.0" />
-    <PackageVersion Include="OpenTelemetry.Api" Version="1.12.0" />
-    <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.12.0" />
+    <PackageVersion Include="OpenTelemetry.Api" Version="1.16.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.16.0" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.16.0" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.16.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
@@ -95,7 +96,7 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageVersion Include="TUnit" Version="0.19.116" />
     <PackageVersion Include="TUnit.Assertions" Version="0.19.116" />
-    <PackageVersion Include="FluentValidation" Version="11.11.0" />
+    <PackageVersion Include="FluentValidation" Version="12.1.1" />
     <PackageVersion Include="FluentValidation.DependencyInjectionExtensions" Version="12.1.1" />
     <PackageVersion Include="Mapster" Version="10.0.7" />
     <PackageVersion Include="MediatR" Version="14.1.0" />
@@ -106,8 +107,10 @@
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageVersion Include="System.Text.Json" Version="10.0.9" />
     <PackageVersion Include="Serilog" Version="4.2.0" />
-    <PackageVersion Include="Stripe.net" Version="48.1.0" />
-    <PackageVersion Include="AWSSDK.S3" Version="4.0.1.1" />
+    <PackageVersion Include="Stripe.net" Version="52.0.0" />
+    <PackageVersion Include="AWSSDK.Core" Version="4.0.9" />
+    <PackageVersion Include="AWSSDK.S3" Version="4.0.24.3" />
+    <PackageVersion Include="AWSSDK.SecurityToken" Version="3.7.401.25" />
     <PackageVersion Include="FigletFontArt" Version="1.0.0" />
     <PackageVersion Include="JetBrains.Annotations" Version="2025.2.4" />
     <PackageVersion Include="Karambolo.PO" Version="1.11.1" />
@@ -118,7 +121,7 @@
     <PackageVersion Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageVersion Include="System.CommandLine.NamingConventionBinder" Version="2.0.0-beta4.22272.1" />
     <PackageVersion Include="System.CommandLine.Hosting" Version="0.4.0-alpha.22272.1" />
-    <PackageVersion Include="System.Configuration.ConfigurationManager" Version="10.0.0" />
+    <PackageVersion Include="System.Configuration.ConfigurationManager" Version="10.0.9" />
     <PackageVersion Include="Yarp.ReverseProxy" Version="2.3.0" />
     <PackageVersion Include="Aspire.Azure.Storage.Blobs" Version="13.4.3" />
     <PackageVersion Include="Aspire.Hosting" Version="13.4.3" />
@@ -133,7 +136,7 @@
     <PackageVersion Include="CommunityToolkit.Aspire.Hosting.PostgreSQL.Extensions" Version="13.4.0" />
     <PackageVersion Include="Azure.Security.KeyVault.Secrets" Version="4.11.0" />
     <PackageVersion Include="Scrutor" Version="7.0.0" />
-    <PackageVersion Include="Microsoft.FeatureManagement" Version="3.2.0" />
+    <PackageVersion Include="Microsoft.FeatureManagement" Version="4.5.0" />
     <PackageVersion Include="Asp.Versioning.Mvc" Version="8.1.0" />
     <PackageVersion Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.1.0" />
     <PackageVersion Include="Pulumi" Version="3.79.0" />
@@ -150,10 +153,10 @@
     <PackageVersion Include="StrawberryShake.Transport.Http" Version="15.1.3" />
     <PackageVersion Include="StrawberryShake.Transport.WebSockets" Version="15.1.3" />
     <PackageVersion Include="Z.Blazor.Diagrams" Version="3.0.4.1" />
-    <PackageVersion Include="Z.Blazor.Diagrams.Core" Version="3.0.3" />
-    <PackageVersion Include="Z.Blazor.Diagrams.Algorithms" Version="3.0.3" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.0" />
+    <PackageVersion Include="Z.Blazor.Diagrams.Core" Version="3.0.4.1" />
+    <PackageVersion Include="Z.Blazor.Diagrams.Algorithms" Version="3.0.4.1" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.9" />
     <PackageVersion Include="Blazor.Diagram" Version="2.0.0" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.5" />
     <!-- Added missing -->


### PR DESCRIPTION
…ncy and security

### Summary & Motivation

A brief description of the changes in this pull request explaining why these changes are necessary. Please delete this paragraph.

### Checklist for Pull Request - Merge from development into main (production) branch

- [ ] A Label has been added to the Pull Request
- [ ] Automated tests have been added
- [ ] Documentation has been updated automatically or manual


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add repo-level `.dockerignore` and align package versions to improve build safety, consistency, and security. Update the web Dockerfile to support TypeScript builds and move plugin handling into the build stage.

- **Dependencies**
  - Enable `CentralPackageTransitivePinningEnabled` for consistent transitive versions.
  - Standardize to `10.0.9` across `Microsoft.Extensions`, `EF Core`, `ASP.NET Core`, and `System.*`.
  - Upgrade `OpenTelemetry.Api` to `1.16.0`.
  - Bump key libs: `AWSSDK.Core` `4.0.9` (and `S3` `4.0.24.3`), `Stripe.net` `52.0.0`, `Resend` `0.5.1`, `FluentValidation` `12.1.1`, `Npgsql` `10.0.3`, `Z.Blazor.Diagrams` `3.0.4.1`.

- **Build**
  - Add `Code/.dockerignore` to reduce build context and exclude secrets, logs, and build outputs.
  - Install Node.js 20 in the build stage for `Microsoft.TypeScript.MSBuild` (UI kit TypeScript).
  - Create `/app/plugins` during build and copy from build stage to runtime for safer, reproducible plugin injection.

<sup>Written for commit 5f5793bc185c4c1704d2966eb111e94d3fd080d3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/saas-factory-labs/Saas-Factory/pull/249?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

