### PR TITLE
feat: Implement InMemoryTicketStore for OIDC authentication ticket ma…

### DIFF
--- a/Code/DeploymentManager/DeploymentManager.Web/Program.cs
+++ b/Code/DeploymentManager/DeploymentManager.Web/Program.cs
@@ -10,6 +10,7 @@ using AppBlueprint.UiKit.Services;
 using DeploymentManager.Web.Components;
 using DeploymentManager.Web.Services;
 // using DeploymentManager.Web.Services.Impersonation; // re-enable with the impersonation DI block below
+using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.HttpOverrides;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -39,7 +40,14 @@ builder.Host.UseDefaultServiceProvider((context, options) =>
 builder.Services.AddAppBlueprintConfiguration(builder.Configuration, builder.Environment);
 builder.Services.AddScoped<ICurrentTenantService, NullCurrentTenantService>();
 
-builder.WebHost.ConfigureKestrel(options => options.AddServerHeader = false);
+builder.WebHost.ConfigureKestrel(options =>
+{
+    options.AddServerHeader = false;
+    // OIDC auth cookies (access + refresh + ID tokens + claims) exceed the 32KB default.
+    // Raising to 64KB keeps single-instance deploys working; the proper fix is the
+    // in-memory ticket store registered below which shrinks the cookie to a session ID.
+    options.Limits.MaxRequestHeadersTotalSize = 65_536;
+});
 
 if (builder.Environment.IsDevelopment())
 {
@@ -64,6 +72,13 @@ builder.Services.AddCascadingAuthenticationState();
 builder.Services.AddUiKit();
 builder.Services.AddHttpContextAccessor();
 builder.Services.AddWebAuthentication(builder.Configuration, builder.Environment);
+
+// Store OIDC tickets server-side so the browser cookie is a small GUID instead of
+// multi-chunk JWT headers that breach Kestrel's 431 limit.
+builder.Services.AddMemoryCache();
+builder.Services.AddSingleton<InMemoryTicketStore>();
+builder.Services.AddOptions<CookieAuthenticationOptions>("Logto.Cookie")
+    .PostConfigure<InMemoryTicketStore>((options, store) => options.SessionStore = store);
 
 // DeploymentManager-specific services
 builder.Services.AddScoped<IMenuConfigurationService, MenuConfigurationService>();

--- a/Code/DeploymentManager/DeploymentManager.Web/Services/InMemoryTicketStore.cs
+++ b/Code/DeploymentManager/DeploymentManager.Web/Services/InMemoryTicketStore.cs
@@ -1,0 +1,40 @@
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace DeploymentManager.Web.Services;
+
+// Stores the full OIDC authentication ticket (access + refresh + ID tokens + all claims)
+// server-side in the memory cache. The browser cookie becomes a small GUID key instead of
+// a multi-chunk header that trips the HTTP 431 limit on large Logto token payloads.
+//
+// Trade-off: tickets are lost on container restart (users must re-authenticate). Acceptable
+// for a single-instance internal tool. Switch to a Redis-backed store for multi-instance.
+public sealed class InMemoryTicketStore(IMemoryCache cache) : ITicketStore
+{
+    public Task<string> StoreAsync(AuthenticationTicket ticket)
+    {
+        string key = Guid.NewGuid().ToString("N");
+        RenewAsync(key, ticket);
+        return Task.FromResult(key);
+    }
+
+    public Task RenewAsync(string key, AuthenticationTicket ticket)
+    {
+        DateTimeOffset expiry = ticket.Properties.ExpiresUtc ?? DateTimeOffset.UtcNow.AddHours(12);
+        cache.Set(key, ticket, expiry);
+        return Task.CompletedTask;
+    }
+
+    public Task<AuthenticationTicket?> RetrieveAsync(string key)
+    {
+        cache.TryGetValue(key, out AuthenticationTicket? ticket);
+        return Task.FromResult(ticket);
+    }
+
+    public Task RemoveAsync(string key)
+    {
+        cache.Remove(key);
+        return Task.CompletedTask;
+    }
+}


### PR DESCRIPTION
…nagement

### Summary & Motivation

A brief description of the changes in this pull request explaining why these changes are necessary. Please delete this paragraph.

### Checklist for Pull Request - Merge from development into main (production) branch

- [ ] A Label has been added to the Pull Request
- [ ] Automated tests have been added
- [ ] Documentation has been updated automatically or manual


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Store OIDC auth tickets server-side and shrink the `Logto.Cookie` to a small session key to prevent 431 Request Header Too Large errors. Also raises the header size limit to 64KB for safety during rollout.

- **New Features**
  - Add `InMemoryTicketStore` (`ITicketStore`) backed by `IMemoryCache`; `Logto.Cookie` now stores a GUID session key instead of full tokens.
  - Register cache/store and bump `MaxRequestHeadersTotalSize` to 64KB to avoid header overflows.

- **Migration**
  - Single-instance only; tickets are cleared on app restart. For multi-instance, use a distributed ticket store (e.g., Redis).

<sup>Written for commit 86b6e3cea8deee818776147fe9eb4c708f2deff9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/saas-factory-labs/Saas-Factory/pull/253?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

