### PR TITLE
feat: Add GitHub Actions workflows for deployment and package publish…

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,6 +9,10 @@
 **/*.exe
 **/*.pdb
 
+# Exception: pre-downloaded admin plugin DLLs (populated by download-admin-plugins.ps1 in CI)
+!Code/DeploymentManager/plugins/*.dll
+!Code/DeploymentManager/plugins/*.pdb
+
 # Environment and secrets
 **/.env
 **/.env.*

--- a/.github/workflows/deploy-deploymentmanager.yml
+++ b/.github/workflows/deploy-deploymentmanager.yml
@@ -1,0 +1,64 @@
+name: "🚀 Deploy: DeploymentManager.Web"
+
+on:
+  workflow_dispatch:
+    inputs:
+      plugin_packages:
+        description: 'Plugin packages (format: "PackageId:Version, ...")'
+        required: false
+        default: ''
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}/deploymentmanager-web
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+
+      # Download admin plugin DLLs into Code/DeploymentManager/plugins/ before docker build.
+      # Plugin names live in a GitHub Actions variable (ADMIN_PLUGIN_PACKAGES) so this
+      # public repo never contains private app identifiers.
+      - name: Download admin plugins
+        shell: pwsh
+        env:
+          ADMIN_PLUGIN_PACKAGES: ${{ vars.ADMIN_PLUGIN_PACKAGES || inputs.plugin_packages }}
+          ADMIN_PLUGINS_FEED_OWNER: Trubador
+          PLUGINS_FEED_TOKEN: ${{ secrets.PLUGINS_FEED_TOKEN }}
+        run: |
+          pwsh Code/DeploymentManager/Scripts/download-admin-plugins.ps1 `
+            -OutputDir Code/DeploymentManager/plugins
+
+      - name: Log into GHCR
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3.7.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051  # v5.10.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=sha,prefix=
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Code/DeploymentManager/DeploymentManager.Web/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: BUILD_CONFIGURATION=Release

--- a/.github/workflows/publish-adminportalkernel-github-packages.yml
+++ b/.github/workflows/publish-adminportalkernel-github-packages.yml
@@ -1,0 +1,65 @@
+name: "📦 Publish AdminPortalKernel to GitHub Packages"
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        with:
+          fetch-depth: 0  # Full history needed for GitVersion
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@baa11fbfe1d6520db94683bd5c7a3818018e4309  # v5.1.0
+        with:
+          dotnet-version: '10.0.x'
+          global-json-file: global.json
+
+      - name: Install GitVersion
+        run: |
+          export PATH="$PATH:/root/.dotnet/tools"
+          dotnet tool install --global GitVersion.Tool --version 6.1.0
+
+      - name: Determine version
+        id: version
+        run: |
+          export PATH="$PATH:/root/.dotnet/tools"
+          VERSION=$(dotnet-gitversion /output json 2>/dev/null | jq -r '.SemVer // "0.1.0"')
+          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Restore dependencies
+        working-directory: Code/AppBlueprint/Shared-Modules/AppBlueprint.AdminPortalKernel
+        run: dotnet restore
+
+      - name: Build
+        working-directory: Code/AppBlueprint/Shared-Modules/AppBlueprint.AdminPortalKernel
+        run: dotnet build --configuration Release --no-restore
+
+      - name: Pack
+        working-directory: Code/AppBlueprint/Shared-Modules/AppBlueprint.AdminPortalKernel
+        run: |
+          dotnet pack --configuration Release --no-build \
+            --output ./output \
+            -p:PackageVersion=${{ env.VERSION }}
+
+      - name: Push to GitHub Packages (Trubador)
+        working-directory: Code/AppBlueprint/Shared-Modules/AppBlueprint.AdminPortalKernel
+        env:
+          TRUBADOR_NUGET_PAT: ${{ secrets.TRUBADOR_NUGET_PAT }}
+        run: |
+          dotnet nuget push ./output/*.nupkg \
+            --api-key "$TRUBADOR_NUGET_PAT" \
+            --source https://nuget.pkg.github.com/Trubador/index.json \
+            --skip-duplicate

--- a/Code/DeploymentManager/DeploymentManager.Web/Dockerfile
+++ b/Code/DeploymentManager/DeploymentManager.Web/Dockerfile
@@ -55,8 +55,10 @@ COPY Code/AppBlueprint/ Code/AppBlueprint/
 WORKDIR /src/Code/DeploymentManager/DeploymentManager.Web
 RUN dotnet build "DeploymentManager.Web.csproj" -c "$BUILD_CONFIGURATION" -o /app/build
 
-# Empty plugins dir — always present so the final stage COPY never fails.
+# Plugins dir: populated by download-admin-plugins.ps1 in CI before docker build.
+# Empty on Railway/git builds (no admin portals); contains plugin DLLs in CI builds.
 RUN mkdir -p /app/plugins
+COPY Code/DeploymentManager/plugins/ /app/plugins/
 
 FROM build AS publish
 ARG BUILD_CONFIGURATION=Release


### PR DESCRIPTION
…ing, update Dockerfile to include plugin DLLs

### Summary & Motivation

A brief description of the changes in this pull request explaining why these changes are necessary. Please delete this paragraph.

### Checklist for Pull Request - Merge from development into main (production) branch

- [ ] A Label has been added to the Pull Request
- [ ] Automated tests have been added
- [ ] Documentation has been updated automatically or manual


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add deployment and package publish workflows, and wire plugin DLLs into the Docker build. This enables pushing `DeploymentManager.Web` images to `ghcr.io` and publishing `AppBlueprint.AdminPortalKernel` to GitHub Packages.

- **New Features**
  - Add `deploy-deploymentmanager.yml`: builds and pushes `DeploymentManager.Web` image to `ghcr.io`, downloads admin plugin DLLs before build, tags by `sha` and `latest` on `main` (`actions/checkout`, `docker/login-action`, `docker/metadata-action`, `docker/build-push-action`).
  - Add `publish-adminportalkernel-github-packages.yml`: builds, packs, and pushes `AppBlueprint.AdminPortalKernel` NuGet on `v*.*.*` tags or manual trigger (`actions/checkout`, `actions/setup-dotnet`, `GitVersion.Tool`).
  - Update Dockerfile to copy `Code/DeploymentManager/plugins/` into `/app/plugins/`; update `.dockerignore` to allow `*.dll`/`*.pdb` in that folder.

- **Migration**
  - Configure secrets: `PLUGINS_FEED_TOKEN` (plugin feed) and `TRUBADOR_NUGET_PAT` (NuGet push).
  - Optional: set repo/org variable `ADMIN_PLUGIN_PACKAGES` or pass `plugin_packages` input when running the deploy workflow.

<sup>Written for commit 06a78817f5a54854e108e9f890a0ba3849b7966d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/saas-factory-labs/Saas-Factory/pull/255?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

