### PR TITLE
feat: Update GitHub Actions workflow to include environment input and…

### DIFF
--- a/.github/workflows/deploy-deploymentmanager.yml
+++ b/.github/workflows/deploy-deploymentmanager.yml
@@ -4,61 +4,51 @@ on:
   workflow_dispatch:
     inputs:
       plugin_packages:
-        description: 'Plugin packages (format: "PackageId:Version, ...")'
+        description: 'Plugin packages — overrides ADMIN_PLUGIN_PACKAGES variable (format: "PackageId:Version, ...")'
         required: false
         default: ''
-
-permissions:
-  contents: read
-  packages: write
-
-env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}/deploymentmanager-web
+      environment:
+        description: 'Target Railway environment'
+        required: true
+        default: 'production'
+        type: choice
+        options:
+          - production
+          - staging
 
 jobs:
-  build-and-push:
+  deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
-      # Download admin plugin DLLs into Code/DeploymentManager/plugins/ before docker build.
+      # Download admin plugin DLLs into Code/DeploymentManager/plugins/ before railway up.
       # Plugin names live in a GitHub Actions variable (ADMIN_PLUGIN_PACKAGES) so this
       # public repo never contains private app identifiers.
       - name: Download admin plugins
         shell: pwsh
         env:
-          ADMIN_PLUGIN_PACKAGES: ${{ vars.ADMIN_PLUGIN_PACKAGES || inputs.plugin_packages }}
+          ADMIN_PLUGIN_PACKAGES: ${{ inputs.plugin_packages || vars.ADMIN_PLUGIN_PACKAGES }}
           ADMIN_PLUGINS_FEED_OWNER: Trubador
           PLUGINS_FEED_TOKEN: ${{ secrets.PLUGINS_FEED_TOKEN }}
         run: |
           pwsh Code/DeploymentManager/Scripts/download-admin-plugins.ps1 `
             -OutputDir Code/DeploymentManager/plugins
 
-      - name: Log into GHCR
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3.7.0
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install Railway CLI
+        run: npm install -g @railway/cli@3.12.2 --ignore-scripts
 
-      - name: Extract Docker metadata
-        id: meta
-        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051  # v5.10.0
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: |
-            type=sha,prefix=
-            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
-
-      - name: Build and push
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: Code/DeploymentManager/DeploymentManager.Web/Dockerfile
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          build-args: BUILD_CONFIGURATION=Release
+      # railway up sends the repo root (including the populated plugins/ folder) to
+      # Railway's builder. Railway runs the Dockerfile from railway.toml.
+      - name: Deploy to Railway
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN_DEPLOYMENTMANAGER }}
+        run: |
+          railway up \
+            --service deploymentmanager-web \
+            --environment ${{ inputs.environment }} \
+            --detach

--- a/Code/DeploymentManager/DeploymentManager.Web/railway.toml
+++ b/Code/DeploymentManager/DeploymentManager.Web/railway.toml
@@ -1,0 +1,10 @@
+[build]
+builder = "DOCKERFILE"
+dockerfilePath = "Code/DeploymentManager/DeploymentManager.Web/Dockerfile"
+
+[deploy]
+startCommand = "dotnet DeploymentManager.Web.dll"
+healthcheckPath = "/health"
+healthcheckTimeout = 60
+restartPolicyType = "ON_FAILURE"
+restartPolicyMaxRetries = 3


### PR DESCRIPTION
… deploy to Railway, add railway.toml for deployment configuration

### Summary & Motivation

A brief description of the changes in this pull request explaining why these changes are necessary. Please delete this paragraph.

### Checklist for Pull Request - Merge from development into main (production) branch

- [ ] A Label has been added to the Pull Request
- [ ] Automated tests have been added
- [ ] Documentation has been updated automatically or manual


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches deployment to Railway using `railway up`, adds an environment selector (staging/production), and configures deployment via `railway.toml`. Removes GHCR image build/push from the workflow.

- **New Features**
  - New `environment` input to target Railway `production` or `staging`.
  - Deploys via `@railway/cli@3.12.2` using `RAILWAY_TOKEN_DEPLOYMENTMANAGER`.
  - Adds `railway.toml` (Dockerfile path, health check, restart policy).
  - `plugin_packages` input now overrides the `ADMIN_PLUGIN_PACKAGES` variable.

<sup>Written for commit 20c6f622e9899e4655ca1e3c8994359b27dc1379. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/saas-factory-labs/Saas-Factory/pull/256?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Transitioned deployment infrastructure from Docker build-and-push pipeline to Railway platform
  * Added environment selection between production and staging deployments
  * Configured health check monitoring with automatic restart policies on service failures
  * Set maximum retry limit of 3 attempts and 60-second timeout for enhanced reliability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->