### PR TITLE
fix: Enclose service variable in quotes for proper command execution …

### DIFF
--- a/.github/workflows/deploy-deploymentmanager.yml
+++ b/.github/workflows/deploy-deploymentmanager.yml
@@ -51,7 +51,7 @@ jobs:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN_DEPLOYMENTMANAGER }}
         run: |
           railway up \
-            --service ${{ vars.RAILWAY_DM_SERVICE }} \
+            --service "${{ vars.RAILWAY_DM_SERVICE }}" \
             --environment ${{ inputs.environment }} \
             --ci \
             --detach


### PR DESCRIPTION
…in deployment

### Summary & Motivation

A brief description of the changes in this pull request explaining why these changes are necessary. Please delete this paragraph.

### Checklist for Pull Request - Merge from development into main (production) branch

- [ ] A Label has been added to the Pull Request
- [ ] Automated tests have been added
- [ ] Documentation has been updated automatically or manual


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Quote the `${{ vars.RAILWAY_DM_SERVICE }}` value in the deploy workflow so the `railway up --service` flag receives the full string. This prevents parsing issues and failed deployments when the service name includes spaces or special characters.

<sup>Written for commit d42daf6b19b02bda3c1658fb6af653dd3bdaf869. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/saas-factory-labs/Saas-Factory/pull/258?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

