### PR TITLE
fix: Remove healthcheck configuration from railway.toml

### DIFF
--- a/railway.toml
+++ b/railway.toml
@@ -4,7 +4,5 @@ dockerfilePath = "Code/DeploymentManager/DeploymentManager.Web/Dockerfile"
 
 [deploy]
 startCommand = "dotnet DeploymentManager.Web.dll"
-healthcheckPath = "/health"
-healthcheckTimeout = 60
 restartPolicyType = "ON_FAILURE"
 restartPolicyMaxRetries = 3


### PR DESCRIPTION
### Summary & Motivation

A brief description of the changes in this pull request explaining why these changes are necessary. Please delete this paragraph.

### Checklist for Pull Request - Merge from development into main (production) branch

- [ ] A Label has been added to the Pull Request
- [ ] Automated tests have been added
- [ ] Documentation has been updated automatically or manual


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed healthcheck configuration from railway.toml to use Railway’s default behavior and simplify the deploy setup.
Specifically, deleted `healthcheckPath` and `healthcheckTimeout` from the `[deploy]` section.

<sup>Written for commit 670d691a4b98f8eddc510cbcabe25fa6da71b015. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/saas-factory-labs/Saas-Factory/pull/259?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

