### PR TITLE
feat: Add debug input to deployment workflow and update Railway CLI i…

### DIFF
--- a/.github/workflows/deploy-deploymentmanager.yml
+++ b/.github/workflows/deploy-deploymentmanager.yml
@@ -15,6 +15,11 @@ on:
         options:
           - production
           - staging
+      debug:
+        description: 'Enable Railway debug logging'
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   deploy:
@@ -40,7 +45,7 @@ jobs:
             -OutputDir Code/DeploymentManager/plugins
 
       - name: Install Railway CLI
-        run: npm install -g @railway/cli@3.12.2 --ignore-scripts
+        run: npm install -g @railway/cli
 
       # railway up sends the repo root (including the populated plugins/ folder) to
       # Railway's cloud builder which runs the Dockerfile.
@@ -49,6 +54,7 @@ jobs:
       - name: Deploy to Railway
         env:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN_DEPLOYMENTMANAGER }}
+          RAILWAY_DEBUG: ${{ inputs.debug && '1' || '0' }}
         run: |
           railway up \
             --service "${{ vars.RAILWAY_DM_SERVICE }}" \


### PR DESCRIPTION
…nstallation

### Summary & Motivation

A brief description of the changes in this pull request explaining why these changes are necessary. Please delete this paragraph.

### Checklist for Pull Request - Merge from development into main (production) branch

- [ ] A Label has been added to the Pull Request
- [ ] Automated tests have been added
- [ ] Documentation has been updated automatically or manual

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `debug` toggle to the deployment workflow to enable verbose Railway logs, and switches Railway CLI installation to the latest version. Improves troubleshooting during manual deploys with no change to defaults.

- **New Features**
  - Adds `debug` input to workflow dispatch; sets `RAILWAY_DEBUG` to `1` when true, `0` when false (default: false).

- **Dependencies**
  - Installs latest `@railway/cli` globally instead of pinning `3.12.2`, and removes `--ignore-scripts` for proper setup.

<sup>Written for commit 3e18f70cbadb0ca6f8d18914093544a44884e620. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/saas-factory-labs/Saas-Factory/pull/260?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

