### PR TITLE
fix: Disable package generation during Docker build for DeploymentMan…

### DIFF
--- a/Code/DeploymentManager/DeploymentManager.Web/Dockerfile
+++ b/Code/DeploymentManager/DeploymentManager.Web/Dockerfile
@@ -53,7 +53,7 @@ COPY Code/DeploymentManager/ Code/DeploymentManager/
 COPY Code/AppBlueprint/ Code/AppBlueprint/
 
 WORKDIR /src/Code/DeploymentManager/DeploymentManager.Web
-RUN dotnet build "DeploymentManager.Web.csproj" -c "$BUILD_CONFIGURATION" -o /app/build
+RUN dotnet build "DeploymentManager.Web.csproj" -c "$BUILD_CONFIGURATION" -o /app/build -p:GeneratePackageOnBuild=false
 
 # Plugins dir: populated by download-admin-plugins.ps1 in CI before docker build.
 # Empty on Railway/git builds (no admin portals); contains plugin DLLs in CI builds.


### PR DESCRIPTION
…ager.Web

### Summary & Motivation

A brief description of the changes in this pull request explaining why these changes are necessary. Please delete this paragraph.

### Checklist for Pull Request - Merge from development into main (production) branch

- [ ] A Label has been added to the Pull Request
- [ ] Automated tests have been added
- [ ] Documentation has been updated automatically or manual


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable package generation during Docker builds for DeploymentManager.Web to avoid producing unused packages and speed up build time. Adds the GeneratePackageOnBuild=false flag to the dotnet build step in the Dockerfile.

<sup>Written for commit a0924b512b52f7faeae126f8388fbe4dacf6f6a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/saas-factory-labs/Saas-Factory/pull/263?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker build configuration to optimize the build process for DeploymentManager.Web.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->