### PR TITLE
fix: Disable package generation during Docker publish in Dockerfile

### DIFF
--- a/Code/DeploymentManager/DeploymentManager.Web/Dockerfile
+++ b/Code/DeploymentManager/DeploymentManager.Web/Dockerfile
@@ -62,7 +62,11 @@ COPY Code/DeploymentManager/plugins/ /app/plugins/
 
 FROM build AS publish
 ARG BUILD_CONFIGURATION=Release
-RUN dotnet publish "DeploymentManager.Web.csproj" -c "$BUILD_CONFIGURATION" -o /app/publish /p:UseAppHost=false
+RUN dotnet publish "DeploymentManager.Web.csproj" \
+    -c "$BUILD_CONFIGURATION" \
+    -o /app/publish \
+    /p:UseAppHost=false \
+    -p:GeneratePackageOnBuild=false
 
 FROM base AS final
 USER $APP_UID


### PR DESCRIPTION
### Summary & Motivation

A brief description of the changes in this pull request explaining why these changes are necessary. Please delete this paragraph.

### Checklist for Pull Request - Merge from development into main (production) branch

- [ ] A Label has been added to the Pull Request
- [ ] Automated tests have been added
- [ ] Documentation has been updated automatically or manual


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable package generation in the Dockerfile publish stage by adding -p:GeneratePackageOnBuild=false to dotnet publish. This speeds up Docker builds and avoids unnecessary artifacts in /app/publish.

<sup>Written for commit e3aa833d0a19415492f0bfc64b64257048b2fffb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/saas-factory-labs/Saas-Factory/pull/264?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

