### PR TITLE
Potential fix for code scanning alert no. 474: Exposure of private information

### DIFF
--- a/Code/AppBlueprint/Shared-Modules/Infrastructure/AppBlueprint.Infrastructure.Email/RazorEmailTemplateService.cs
+++ b/Code/AppBlueprint/Shared-Modules/Infrastructure/AppBlueprint.Infrastructure.Email/RazorEmailTemplateService.cs
@@ -2,6 +2,8 @@ using AppBlueprint.Application.Interfaces;
 using Microsoft.Extensions.Logging;
 using RazorLight;
 using Resend;
+using System.Security.Cryptography;
+using System.Text;
 
 namespace AppBlueprint.Infrastructure.Email;
 
@@ -108,9 +110,9 @@ public sealed class RazorEmailTemplateService : IEmailTemplateService
             if (response.Content != Guid.Empty)
             {
                 _logger.LogInformation(
-                    "Sent templated email {TemplateName} to {Recipient} with ID {EmailId}",
+                    "Sent templated email {TemplateName} to recipient fingerprint {RecipientFingerprint} with ID {EmailId}",
                     templateName,
-                    to,
+                    CreateRecipientFingerprint(to),
                     response.Content);
 
                 return response.Content;
@@ -123,18 +125,18 @@ public sealed class RazorEmailTemplateService : IEmailTemplateService
         {
             _logger.LogError(
                 ex,
-                "Network error sending templated email {TemplateName} to {Recipient}",
+                "Network error sending templated email {TemplateName} to recipient fingerprint {RecipientFingerprint}",
                 templateName,
-                to);
+                CreateRecipientFingerprint(to));
             throw;
         }
         catch (TaskCanceledException ex)
         {
             _logger.LogError(
                 ex,
-                "Timeout sending templated email {TemplateName} to {Recipient}",
+                "Timeout sending templated email {TemplateName} to recipient fingerprint {RecipientFingerprint}",
                 templateName,
-                to);
+                CreateRecipientFingerprint(to));
             throw;
         }
         catch (RazorLightException ex)
@@ -145,5 +147,11 @@ public sealed class RazorEmailTemplateService : IEmailTemplateService
                 templateName);
             throw;
         }
+    }
+
+    private static string CreateRecipientFingerprint(string recipient)
+    {
+        byte[] hash = SHA256.HashData(Encoding.UTF8.GetBytes(recipient));
+        return Convert.ToHexString(hash.AsSpan(0, 8));
     }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/saas-factory-labs/Saas-Factory/security/code-scanning/474](https://github.com/saas-factory-labs/Saas-Factory/security/code-scanning/474)

To fix this without changing functional behavior, stop logging the raw `to` email address and replace it with a non-sensitive surrogate (for example, a deterministic hash fingerprint) so logs remain useful for correlation/debugging without exposing private data.

Best change in this code:
- **File:** `Code/AppBlueprint/Shared-Modules/Infrastructure/AppBlueprint.Infrastructure.Email/RazorEmailTemplateService.cs`
- Update the three log statements that currently include `{Recipient}`/`to`.
- Add a private helper method (inside the same class) that computes a stable SHA-256-based short fingerprint from the recipient string.
- Keep `to` unchanged for actual email sending (`message.To = to;`), only sanitize logging.

This preserves functionality (email still sent exactly the same) while preventing private data exposure in external logs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace logging of raw email recipients with a short, deterministic SHA-256 fingerprint in `RazorEmailTemplateService` to resolve code scanning alert 474 while keeping email delivery unchanged.

- **Bug Fixes**
  - Swapped `{Recipient}` for `{RecipientFingerprint}` in three log statements.
  - Added `CreateRecipientFingerprint(string)` that returns the first 8 bytes of the SHA-256 hash as hex.
  - No change to sending logic (`message.To = to`); only logging was sanitized.

<sup>Written for commit de36c9445d093bc896e2d65a9b832a61803ba268. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/saas-factory-labs/Saas-Factory/pull/287?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

