### PR TITLE
Potential fix for code scanning alert no. 406: Log entries created from user input

### DIFF
--- a/Code/AppBlueprint/AppBlueprint.Web/Services/HttpTenantSearchService.cs
+++ b/Code/AppBlueprint/AppBlueprint.Web/Services/HttpTenantSearchService.cs
@@ -40,7 +40,10 @@ internal sealed class HttpTenantSearchService : ISearchService<TenantEntity>
 
         if (response is null)
         {
-            _logger.LogWarning("Tenant search API returned null response for query: {QueryText}", query.QueryText);
+            string sanitizedQueryTextForLog = (query.QueryText ?? string.Empty)
+                .Replace("\r", " ")
+                .Replace("\n", " ");
+            _logger.LogWarning("Tenant search API returned null response for query: {QueryText}", sanitizedQueryTextForLog);
             return new SearchResult<TenantEntity>
             {
                 Items = [],


### PR DESCRIPTION
Potential fix for [https://github.com/saas-factory-labs/Saas-Factory/security/code-scanning/406](https://github.com/saas-factory-labs/Saas-Factory/security/code-scanning/406)

To fix log forging, sanitize user-controlled text before writing it to logs by removing line-break characters (and ideally other control chars).  
The best minimal fix here is in `HttpTenantSearchService.SearchAsync`, right before logging on the null-response branch:

- Create a sanitized local variable from `query.QueryText`.
- Replace `\r` and `\n` with safe characters (e.g., space).
- Log the sanitized value instead of raw input.

This preserves functionality (same business behavior and response content), while preventing log entry injection in this sink.  
Only `Code/AppBlueprint/AppBlueprint.Web/Services/HttpTenantSearchService.cs` needs editing. No new dependency is required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sanitize user-provided query text before logging in `HttpTenantSearchService.SearchAsync` to prevent log forging and address code scanning alert 406. Replaces carriage returns and newlines with spaces and logs the sanitized value when the API response is null.

<sup>Written for commit 1c3431eec2d09c3063fae9a40869d06f4b930992. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/saas-factory-labs/Saas-Factory/pull/289?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

