### PR TITLE
Potential fix for code scanning alert no. 407: Log entries created from user input

### DIFF
--- a/Code/AppBlueprint/AppBlueprint.Web/Services/HttpUserSearchService.cs
+++ b/Code/AppBlueprint/AppBlueprint.Web/Services/HttpUserSearchService.cs
@@ -22,6 +22,16 @@ internal sealed class HttpUserSearchService : ISearchService<UserEntity>
         _logger = logger;
     }
 
+    private static string SanitizeForLog(string? value)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return string.Empty;
+        }
+
+        return value.Replace("\r", string.Empty).Replace("\n", string.Empty);
+    }
+
     public async Task<SearchResult<UserEntity>> SearchAsync(SearchQuery query, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(query);
@@ -40,7 +50,7 @@ internal sealed class HttpUserSearchService : ISearchService<UserEntity>
 
         if (response is null)
         {
-            _logger.LogWarning("User search API returned null response for query: {QueryText}", query.QueryText);
+            _logger.LogWarning("User search API returned null response for query: {QueryText}", SanitizeForLog(query.QueryText));
             return new SearchResult<UserEntity>
             {
                 Items = [],


### PR DESCRIPTION
Potential fix for [https://github.com/saas-factory-labs/Saas-Factory/security/code-scanning/407](https://github.com/saas-factory-labs/Saas-Factory/security/code-scanning/407)

To fix log-forging risk, sanitize user-controlled text before writing it to logs by removing line-break/control characters (at minimum `\r` and `\n`). Keep existing behavior otherwise unchanged.

Best fix in this code: in `Code/AppBlueprint/AppBlueprint.Web/Services/HttpUserSearchService.cs`, add a small private helper that normalizes nullable input and strips CR/LF, then use that sanitized value in the warning log call. This keeps the returned `SearchResult` untouched (so functionality remains the same) and only hardens logging.

Changes needed:
- In `HttpUserSearchService` class, add a private static method (e.g., `SanitizeForLog`) that:
  - accepts `string?`
  - returns `string.Empty` for null/empty
  - replaces `"\r"` and `"\n"` with empty strings
- Update line 43 logging call to pass `SanitizeForLog(query.QueryText)` instead of raw `query.QueryText`.
- No additional dependencies required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sanitizes user-provided search text before logging to prevent log forging (Code Scanning alert #407). App behavior and API results are unchanged.

- **Bug Fixes**
  - Added a private helper in `HttpUserSearchService` to normalize null/empty input and strip `\r`/`\n`.
  - Used the sanitized value in the warning log for null API responses.

<sup>Written for commit c77fee057ec90f02c35270c72f35523e4668fa95. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/saas-factory-labs/Saas-Factory/pull/290?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved log safety by removing line breaks from user-entered search text before it is written to logs.
  * Search behavior remains unchanged when no results are returned, continuing to show an empty result set with the original search settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->