### PR TITLE
Potential fix for code scanning alert no. 485: Log entries created from user input

### DIFF
--- a/Code/AppBlueprint/Shared-Modules/AppBlueprint.AdminPortalKernel/Security/AdminAccessGuard.cs
+++ b/Code/AppBlueprint/Shared-Modules/AppBlueprint.AdminPortalKernel/Security/AdminAccessGuard.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using AppBlueprint.AdminPortalKernel.Services;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -114,7 +115,8 @@ public sealed class AdminAccessGuard : IAdminAccessGuard
             : $"{request.AppSlug}:{request.TenantId}";
         if (!_rateLimiter.TryRegisterTenantAccess(userId, tenantScope))
         {
-            _logger.LogWarning("ADMIN_RATE_LIMIT_EXCEEDED | admin={AdminUserId} scope={TenantScope}", userId, tenantScope);
+            string safeTenantScope = SanitizeForLog(tenantScope);
+            _logger.LogWarning("ADMIN_RATE_LIMIT_EXCEEDED | admin={AdminUserId} scope={TenantScope}", userId, safeTenantScope);
             throw new InvalidOperationException("Admin tenant-access rate limit exceeded. Try again later.");
         }
 
@@ -175,5 +177,19 @@ public sealed class AdminAccessGuard : IAdminAccessGuard
             request.Operation, request.AppSlug, email, userId, request.TenantId, isAutomatedBypass, effectiveReason);
 
         return new AdminAccessDecision(effectiveReason, isAutomatedBypass, fingerprint);
+    }
+
+    private static string SanitizeForLog(string value)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return string.Empty;
+        }
+
+        char[] sanitized = value
+            .Select(ch => char.IsControl(ch) ? ' ' : ch)
+            .ToArray();
+
+        return new string(sanitized);
     }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/saas-factory-labs/Saas-Factory/security/code-scanning/485](https://github.com/saas-factory-labs/Saas-Factory/security/code-scanning/485)

Fix by sanitizing user-derived values before writing them to logs. For plain-text log-forging prevention, remove/neutralize CR/LF (and preferably other ASCII control chars) from `tenantScope` before passing it to `_logger`. Keep business behavior unchanged: rate-limiter logic should continue using the original `tenantScope`; only the logged representation should be sanitized.

Best targeted fix in the shown code:
- **File:** `Code/AppBlueprint/Shared-Modules/AppBlueprint.AdminPortalKernel/Security/AdminAccessGuard.cs`
- Add a small private helper in `AdminAccessGuard` (e.g., `SanitizeForLog`) that strips `\r`, `\n`, and other control chars.
- In the rate-limit warning block (around line 117), compute `safeTenantScope = SanitizeForLog(tenantScope)` and log that instead of raw `tenantScope`.

This single sink-side fix addresses all listed variants because they all converge on the same log statement in `AdminAccessGuard`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sanitizes user-derived tenantScope before logging to prevent log forgery and address code scanning alert 485.
Adds a SanitizeForLog helper that replaces any control characters with spaces and uses it in the rate-limit warning (limiter still uses the original value), and merges main to retain the masked-email helper.

<sup>Written for commit b37ac3f10d985dfb45a0c42c3b386c49ccbb6c46. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/saas-factory-labs/SaaS-Factory/pull/292?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

