### PR TITLE
Potential fix for code scanning alert no. 486: Log entries created from user input

### DIFF
--- a/Code/AppBlueprint/Shared-Modules/AppBlueprint.AdminPortalKernel/Security/AdminAccessGuard.cs
+++ b/Code/AppBlueprint/Shared-Modules/AppBlueprint.AdminPortalKernel/Security/AdminAccessGuard.cs
@@ -170,10 +170,22 @@ public sealed class AdminAccessGuard : IAdminAccessGuard
                 effectiveReason, isAutomatedBypass, fingerprint?.Value, now),
             cancellationToken);
 
+        string safeAppSlug = SanitizeForLog(request.AppSlug);
+
         _logger.LogInformation(
             "ADMIN_PORTAL_ACCESS: {Operation} app={Slug} by={AdminEmail} ({AdminUserId}) tenant={TenantId} bypass={Bypass} reason={Reason}",
-            request.Operation, request.AppSlug, email, userId, request.TenantId, isAutomatedBypass, effectiveReason);
+            request.Operation, safeAppSlug, email, userId, request.TenantId, isAutomatedBypass, effectiveReason);
 
         return new AdminAccessDecision(effectiveReason, isAutomatedBypass, fingerprint);
+    }
+
+    private static string SanitizeForLog(string? value)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return string.Empty;
+        }
+
+        return value.Replace("\r", string.Empty).Replace("\n", string.Empty);
     }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/saas-factory-labs/Saas-Factory/security/code-scanning/486](https://github.com/saas-factory-labs/Saas-Factory/security/code-scanning/486)

General fix: sanitize untrusted values before logging by removing CR/LF (and optionally other control characters) so user input cannot inject fake log lines. Keep original values for business/security logic; only sanitize for log output.

Best single fix without changing functionality: in `AdminAccessGuard.cs`, sanitize `request.AppSlug` right before `_logger.LogInformation(...)` and log the sanitized value instead of raw `request.AppSlug`. This fixes all reported variants because they all converge into this one logging sink. Add a small private helper method in the same class (no new dependencies) to strip `\r` and `\n` and handle null/empty safely.

File/region to change:
- `Code/AppBlueprint/Shared-Modules/AppBlueprint.AdminPortalKernel/Security/AdminAccessGuard.cs`
  - In `AuthorizeAsync`, introduce `safeAppSlug` from `request.AppSlug`.
  - Replace logged argument `request.AppSlug` with `safeAppSlug`.
  - Add private static sanitization helper method in class.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sanitize the user-provided app slug and mask the admin email before logging in `AdminAccessGuard.AuthorizeAsync` to prevent log injection (alert 486). Added `SanitizeForLog` to strip line endings and use a masked email for external logs; authorization and SIEM use the original inputs.

<sup>Written for commit ef5ccc71acd420b54361a1eef01de0b599d2e411. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/saas-factory-labs/SaaS-Factory/pull/293?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security logging by sanitizing app identifiers before they are written to access logs.
  * Prevented line breaks from being included in log entries, reducing the risk of log injection.
  * If no app identifier is provided, logs now use a blank value instead of relying on the raw input.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->