### PR TITLE
Potential fix for code scanning alert no. 488: Exposure of private information

### DIFF
--- a/Code/AppBlueprint/Shared-Modules/AppBlueprint.AdminPortalKernel/Security/AdminAccessGuard.cs
+++ b/Code/AppBlueprint/Shared-Modules/AppBlueprint.AdminPortalKernel/Security/AdminAccessGuard.cs
@@ -92,6 +92,7 @@ public sealed class AdminAccessGuard : IAdminAccessGuard
         string? rawUserId = await _userContext.GetUserIdAsync();
         string userId = string.IsNullOrWhiteSpace(rawUserId) ? "unknown" : rawUserId;
         string? email = await _userContext.GetEmailAsync();
+        string emailForExternalUse = MaskEmailForExternalUse(email);
 
         // 2. Lockout (defense in depth - a session locked out mid-flight cannot keep extracting).
         if (_lockout.IsLockedOut(userId, out DateTimeOffset lockoutUntil))
@@ -159,21 +160,40 @@ public sealed class AdminAccessGuard : IAdminAccessGuard
         if (isAutomatedBypass || request.Sensitivity == AdminAccessSensitivity.High)
         {
             await _alerting.RaiseAccessAlertAsync(
-                new AdminAccessAlert(userId, email, request.AppSlug, request.TenantId, effectiveReason, isAutomatedBypass, now),
+                new AdminAccessAlert(userId, emailForExternalUse, request.AppSlug, request.TenantId, effectiveReason, isAutomatedBypass, now),
                 cancellationToken);
         }
 
         // 9. Stream the complete record to the external SIEM on every authorized access.
         await _siem.EmitAsync(
             new AdminAccessAuditPayload(
-                userId, email, request.Operation.ToString(), request.AppSlug, request.TenantId,
+                userId, emailForExternalUse, request.Operation.ToString(), request.AppSlug, request.TenantId,
                 effectiveReason, isAutomatedBypass, fingerprint?.Value, now),
             cancellationToken);
 
         _logger.LogInformation(
             "ADMIN_PORTAL_ACCESS: {Operation} app={Slug} by={AdminEmail} ({AdminUserId}) tenant={TenantId} bypass={Bypass} reason={Reason}",
-            request.Operation, request.AppSlug, email, userId, request.TenantId, isAutomatedBypass, effectiveReason);
+            request.Operation, request.AppSlug, emailForExternalUse, userId, request.TenantId, isAutomatedBypass, effectiveReason);
 
         return new AdminAccessDecision(effectiveReason, isAutomatedBypass, fingerprint);
+    }
+
+    private static string MaskEmailForExternalUse(string? email)
+    {
+        if (string.IsNullOrWhiteSpace(email))
+        {
+            return "unknown";
+        }
+
+        int atIndex = email.IndexOf('@');
+        if (atIndex <= 0 || atIndex == email.Length - 1)
+        {
+            return "redacted";
+        }
+
+        string local = email[..atIndex];
+        string domain = email[(atIndex + 1)..];
+        string maskedLocal = local.Length <= 1 ? "*" : $"{local[0]}***";
+        return $"{maskedLocal}@{domain}";
     }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/saas-factory-labs/Saas-Factory/security/code-scanning/488](https://github.com/saas-factory-labs/Saas-Factory/security/code-scanning/488)

To fix this without changing authorization behavior, stop writing raw `email` to external locations and replace it with a privacy-preserving representation for observability/audit fields.

Best single approach here:
- Keep `email` retrieval for internal logic compatibility, but create a sanitized display value (masked or fallback).
- Use that sanitized value everywhere the payload/log leaves the process:
  - `AdminAccessAlert(...)` constructor call (line ~162)
  - `AdminAccessAuditPayload(...)` constructor call (line ~169)
  - `_logger.LogInformation(...)` argument list (line ~175)
- Add a small private helper in `AdminAccessGuard` to mask emails (e.g., `j***@domain.com`) and return `"unknown"` when missing/invalid.

This addresses all alert variants since all are tied to `email` flowing into external sinks from `GetEmailAsync()`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Masks admin emails before leaving the process to fix code scanning alert 488 and prevent PII exposure. Authorization logic remains unchanged.

- **Bug Fixes**
  - Added a private helper to mask emails (e.g., j***@domain.com). Falls back to "unknown" for empty and "redacted" for invalid formats.
  - Replaced raw `email` with the masked value in alerting, SIEM audit payload, and info logging.

<sup>Written for commit 1aa8682a9586a98142d7e03962f0b985a266ac71. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/saas-factory-labs/Saas-Factory/pull/295?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

