### PR TITLE
Potential fix for code scanning alert no. 489: Exposure of private information

### DIFF
--- a/Code/AppBlueprint/Shared-Modules/AppBlueprint.AdminPortalKernel/Security/AdminAlertingService.cs
+++ b/Code/AppBlueprint/Shared-Modules/AppBlueprint.AdminPortalKernel/Security/AdminAlertingService.cs
@@ -39,11 +39,13 @@ public sealed class AdminAlertingService : IAdminAlertingService
     {
         ArgumentNullException.ThrowIfNull(alert);
 
+        string redactedAdminEmail = string.IsNullOrWhiteSpace(alert.AdminEmail) ? "n/a" : "redacted";
+
         _logger.LogWarning(
             "ADMIN_ACCESS_ALERT | admin={AdminUserId} ({AdminEmail}) app={AppSlug} tenant={TenantId} " +
             "bypass={IsAutomatedBypass} reason={Reason} at={OccurredAtUtc:O}",
             alert.AdminUserId,
-            alert.AdminEmail,
+            redactedAdminEmail,
             alert.AppSlug,
             alert.TenantId,
             alert.IsAutomatedBypass,


### PR DESCRIPTION
Potential fix for [https://github.com/saas-factory-labs/Saas-Factory/security/code-scanning/489](https://github.com/saas-factory-labs/Saas-Factory/security/code-scanning/489)

To fix this without changing existing functionality, stop writing raw `AdminEmail` to logs in `AdminAlertingService`. Keep the `AdminAccessAlert` contract unchanged (so callers and potential non-log transports still work), but redact/mask the email only at the logging sink. This preserves alert behavior and structure while removing direct private-data exposure from logs.

**Best concrete fix in shown code:**
- In `Code/AppBlueprint/Shared-Modules/AppBlueprint.AdminPortalKernel/Security/AdminAlertingService.cs`, update `RaiseAccessAlertAsync` to:
  - compute a sanitized `redactedAdminEmail` (e.g., `"redacted"` when email exists, otherwise `"n/a"`),
  - pass that sanitized value to `_logger.LogWarning` instead of `alert.AdminEmail`.
- No interface or record changes are required.
- No dependency changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacts admin email addresses in AdminAlertingService logs to prevent PII exposure and resolve code scanning alert 489. Keeps the AdminAccessAlert contract unchanged and masks only at the logging sink.

- **Bug Fixes**
  - Log warning now uses a sanitized email value: "redacted" if present, "n/a" if missing.

<sup>Written for commit ae9acd8d9dec2c2d46718a1e00ba4ac78a8257c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/saas-factory-labs/Saas-Factory/pull/296?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

