### PR TITLE
refactor: Simplify URL validation by using ParseUri method in Webhook…

### DIFF
--- a/Code/AppBlueprint/AppBlueprint.Tests/Application/WebhookUrlValidatorTests.cs
+++ b/Code/AppBlueprint/AppBlueprint.Tests/Application/WebhookUrlValidatorTests.cs
@@ -13,7 +13,7 @@ internal sealed class WebhookUrlValidatorTests
     [Arguments("gopher://example.com")]
     public async Task TryValidate_ShouldRejectNonHttpSchemes(string url)
     {
-        bool ok = WebhookUrlValidator.TryValidate(url, out string? error);
+        bool ok = WebhookUrlValidator.TryValidate(ParseUri(url), out string? error);
 
         ok.Should().BeFalse();
         await Assert.That(error).IsNotNull();
@@ -28,7 +28,7 @@ internal sealed class WebhookUrlValidatorTests
     [Arguments("http://172.16.5.4/hook")]
     public async Task TryValidate_ShouldRejectInternalAndMetadataTargets(string url)
     {
-        bool ok = WebhookUrlValidator.TryValidate(url, out string? error);
+        bool ok = WebhookUrlValidator.TryValidate(ParseUri(url), out string? error);
 
         ok.Should().BeFalse(because: $"{url} targets an internal or metadata address");
         await Assert.That(error).IsNotNull();
@@ -40,7 +40,7 @@ internal sealed class WebhookUrlValidatorTests
     [Arguments("//relative/path")]
     public async Task TryValidate_ShouldRejectMalformedUrls(string url)
     {
-        bool ok = WebhookUrlValidator.TryValidate(url, out _);
+        bool ok = WebhookUrlValidator.TryValidate(ParseUri(url), out _);
 
         await Assert.That(ok).IsFalse();
     }
@@ -50,7 +50,7 @@ internal sealed class WebhookUrlValidatorTests
     [Arguments("https://8.8.8.8/callback")]
     public async Task TryValidate_ShouldAcceptPublicHttpsTargets(string url)
     {
-        bool ok = WebhookUrlValidator.TryValidate(url, out string? error);
+        bool ok = WebhookUrlValidator.TryValidate(ParseUri(url), out string? error);
 
         ok.Should().BeTrue(because: error);
         await Assert.That(error).IsNull();
@@ -70,5 +70,20 @@ internal sealed class WebhookUrlValidatorTests
         bool blocked = WebhookUrlValidator.IsBlockedIpAddress(IPAddress.Parse(ip));
 
         await Assert.That(blocked).IsEqualTo(expectedBlocked);
+    }
+
+    private static Uri? ParseUri(string url)
+    {
+        if (Uri.TryCreate(url, UriKind.Absolute, out Uri? absoluteUri))
+        {
+            return absoluteUri;
+        }
+
+        if (Uri.TryCreate(url, UriKind.Relative, out Uri? relativeUri))
+        {
+            return relativeUri;
+        }
+
+        return null;
     }
 }

--- a/Code/AppBlueprint/AppBlueprint.Tests/Integration/TenantSecurityExploitTests.cs
+++ b/Code/AppBlueprint/AppBlueprint.Tests/Integration/TenantSecurityExploitTests.cs
@@ -16,8 +16,7 @@ namespace AppBlueprint.Tests.Integration;
 
 internal sealed class TenantSecurityExploitTests
 {
-    private readonly PostgreSqlContainer _container = new PostgreSqlBuilder()
-        .WithImage("postgres:17-alpine")
+    private readonly PostgreSqlContainer _container = new PostgreSqlBuilder("postgres:17-alpine")
         .Build();
 
     private string ConnectionString => _container.GetConnectionString();

--- a/Code/AppBlueprint/Shared-Modules/AppBlueprint.AdminPortalKernel.Tests/Integration/PostgresFixture.cs
+++ b/Code/AppBlueprint/Shared-Modules/AppBlueprint.AdminPortalKernel.Tests/Integration/PostgresFixture.cs
@@ -93,8 +93,7 @@ internal static class PostgresFixture
         {
             if (_container is null)
             {
-                PostgreSqlContainer container = new PostgreSqlBuilder()
-                    .WithImage("postgres:17-alpine")
+                PostgreSqlContainer container = new PostgreSqlBuilder("postgres:17-alpine")
                     .Build();
 
                 await container.StartAsync();

--- a/Code/AppBlueprint/Shared-Modules/AppBlueprint.Presentation.ApiModule/Controllers/Baseline/WebhookController.cs
+++ b/Code/AppBlueprint/Shared-Modules/AppBlueprint.Presentation.ApiModule/Controllers/Baseline/WebhookController.cs
@@ -72,7 +72,7 @@ public class WebhookController : BaseController
 
         // SECURITY (OWASP A10/SSRF): reject internal, loopback, metadata and non-http(s) targets
         // before persisting, so the delivery service can never be pointed at internal resources.
-        if (!WebhookUrlValidator.TryValidate(request.Url.ToString(), out string? urlError))
+        if (!WebhookUrlValidator.TryValidate(request.Url, out string? urlError))
             return BadRequest(new { Message = urlError });
 
         string tenantId = GetCurrentTenantId();
@@ -103,7 +103,7 @@ public class WebhookController : BaseController
     {
         if (!ModelState.IsValid) return BadRequest(ModelState);
 
-        if (!WebhookUrlValidator.TryValidate(request.Url.ToString(), out string? urlError))
+        if (!WebhookUrlValidator.TryValidate(request.Url, out string? urlError))
             return BadRequest(new { Message = urlError });
 
         WebhookEntity? webhook = await _webhookRepository.GetByIdAsync(id, cancellationToken);


### PR DESCRIPTION
…UrlValidator and update PostgreSqlBuilder instantiation

### Summary & Motivation

A brief description of the changes in this pull request explaining why these changes are necessary. Please delete this paragraph.

### Checklist for Pull Request - Merge from development into main (production) branch

- [ ] A Label has been added to the Pull Request
- [ ] Automated tests have been added
- [ ] Documentation has been updated automatically or manual


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplified webhook URL validation by passing a Uri to TryValidate, ensuring consistent parsing and SSRF checks. Updated integration tests to use the new `PostgreSqlBuilder("postgres:17-alpine")` API.

- **Refactors**
  - `WebhookController` now passes `request.Url` directly to `WebhookUrlValidator.TryValidate` to avoid string parsing duplication.
  - Unit tests updated for the new signature and include a small `ParseUri` helper for test inputs.
  - Integration tests switched to `PostgreSqlBuilder("postgres:17-alpine")` instead of `.WithImage(...)`.

<sup>Written for commit 1b3db5fd2a29580981d4d34b3d5d872484b16b82. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/saas-factory-labs/Saas-Factory/pull/304?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

