### PR TITLE
Refresh nuget.org trusted signer certificates for CI restore

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -7,11 +7,17 @@
     <add key="signatureValidationMode" value="accept" />
 </config>
 <trustedSigners>
-    <!-- NuGet.org repository-signs all packages. Any package from nuget.org with an
-         invalid or missing repository signature will be rejected in require mode,
-         and flagged by `dotnet nuget verify` in accept mode. -->
+    <!-- NuGet.org publishes its active repository-signing certificates in the service index.
+         Keep this list in sync with `nuget trusted-signers sync -Name nuget.org` to avoid
+         NU3034 failures when repository certificates rotate. -->
     <repository name="nuget.org" serviceIndex="https://api.nuget.org/v3/index.json">
-        <certificate fingerprint="0E5F38F57DC1BCC806D8494F4F90FBEBA925C003D7E6D34F3D3E8D2B7910A1E6"
+        <certificate fingerprint="0E5F38F57DC1BCC806D8494F4F90FBCEDD988B46760709CBEEC6F4219AA6157D"
+                     hashAlgorithm="SHA256"
+                     allowUntrustedRoot="false" />
+        <certificate fingerprint="5A2901D6ADA3D18260B9C6DFE2133C95D74B9EEF6AE0E5DC334C8454D1477DF4"
+                     hashAlgorithm="SHA256"
+                     allowUntrustedRoot="false" />
+        <certificate fingerprint="1F4B311D9ACC115C8DC8018B5A49E00FCE6DA8E2855F9F014CA6F34570BC482D"
                      hashAlgorithm="SHA256"
                      allowUntrustedRoot="false" />
     </repository>


### PR DESCRIPTION
### Summary & Motivation

A brief description of the changes in this pull request explaining why these changes are necessary. Please delete this paragraph.

### Checklist for Pull Request - Merge from development into main (production) branch

- [ ] A Label has been added to the Pull Request
- [ ] Automated tests have been added
- [ ] Documentation has been updated automatically or manual


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refresh trusted signer certificates for `nuget.org` in NuGet.config to match the current service index. Prevents `NU3034` failures during CI restores.

- **Bug Fixes**
  - Replaced the outdated fingerprint with three current `nuget.org` repository certificates.
  - Added a note to keep the list synced via `nuget trusted-signers sync -Name nuget.org`.

<sup>Written for commit 2d6227fae449b260afb107435966ac74f8e204f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/saas-factory-labs/Saas-Factory/pull/306?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

