### PR TITLE
Thread CancellationToken through notification services

### DIFF
--- a/Code/AppBlueprint/Shared-Modules/AppBlueprint.Application/Interfaces/IInAppNotificationService.cs
+++ b/Code/AppBlueprint/Shared-Modules/AppBlueprint.Application/Interfaces/IInAppNotificationService.cs
@@ -8,5 +8,5 @@ public interface IInAppNotificationService
     /// <summary>
     /// Sends an in-app notification (stores in DB and broadcasts via SignalR).
     /// </summary>
-    Task SendAsync(SendNotificationRequest request);
+    Task SendAsync(SendNotificationRequest request, CancellationToken cancellationToken = default);
 }

--- a/Code/AppBlueprint/Shared-Modules/AppBlueprint.Application/Interfaces/INotificationService.cs
+++ b/Code/AppBlueprint/Shared-Modules/AppBlueprint.Application/Interfaces/INotificationService.cs
@@ -10,27 +10,27 @@ public interface INotificationService
     /// <summary>
     /// Sends a notification through specified channels.
     /// </summary>
-    Task SendAsync(SendNotificationRequest request);
+    Task SendAsync(SendNotificationRequest request, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Gets recent notifications for the current user.
     /// </summary>
-    Task<IEnumerable<UserNotificationEntity>> GetUserNotificationsAsync(string userId, int count = 20);
+    Task<IEnumerable<UserNotificationEntity>> GetUserNotificationsAsync(string userId, int count = 20, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Gets unread notification count for the current user.
     /// </summary>
-    Task<int> GetUnreadCountAsync(string userId);
+    Task<int> GetUnreadCountAsync(string userId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Marks a notification as read.
     /// </summary>
-    Task MarkAsReadAsync(string notificationId);
+    Task MarkAsReadAsync(string notificationId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Marks all notifications as read for the current user.
     /// </summary>
-    Task MarkAllAsReadAsync(string userId);
+    Task MarkAllAsReadAsync(string userId, CancellationToken cancellationToken = default);
 }
 
 /// <summary>

--- a/Code/AppBlueprint/Shared-Modules/AppBlueprint.Application/Interfaces/IPushNotificationService.cs
+++ b/Code/AppBlueprint/Shared-Modules/AppBlueprint.Application/Interfaces/IPushNotificationService.cs
@@ -10,7 +10,7 @@ public interface IPushNotificationService
     /// <summary>
     /// Sends a push notification to all user devices.
     /// </summary>
-    Task SendAsync(PushNotificationRequest request);
+    Task SendAsync(PushNotificationRequest request, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Sends a push notification to all users in a tenant.
@@ -20,12 +20,12 @@ public interface IPushNotificationService
     /// <summary>
     /// Registers a push notification token for the current user.
     /// </summary>
-    Task RegisterTokenAsync(RegisterPushTokenRequest request);
+    Task RegisterTokenAsync(RegisterPushTokenRequest request, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Unregisters a push notification token.
     /// </summary>
-    Task UnregisterTokenAsync(string token);
+    Task UnregisterTokenAsync(string token, CancellationToken cancellationToken = default);
 }
 
 /// <summary>

--- a/Code/AppBlueprint/Shared-Modules/Infrastructure/AppBlueprint.Infrastructure.Notifications/FirebasePushNotificationService.cs
+++ b/Code/AppBlueprint/Shared-Modules/Infrastructure/AppBlueprint.Infrastructure.Notifications/FirebasePushNotificationService.cs
@@ -87,7 +87,7 @@ public sealed class FirebasePushNotificationService : IPushNotificationService
         }
     }
 
-    public async Task SendAsync(PushNotificationRequest request)
+    public async Task SendAsync(PushNotificationRequest request, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(request);
 
@@ -97,7 +97,7 @@ public sealed class FirebasePushNotificationService : IPushNotificationService
             return;
         }
 
-        List<PushNotificationTokenEntity> tokens = await _tokenRepository.GetActiveByUserIdAsync(request.UserId);
+        List<PushNotificationTokenEntity> tokens = await _tokenRepository.GetActiveByUserIdAsync(request.UserId, cancellationToken);
 
         _logger.LogInformation("Found {Count} active tokens for user {UserId}", tokens.Count, request.UserId);
 
@@ -122,12 +122,12 @@ public sealed class FirebasePushNotificationService : IPushNotificationService
             request.Data,
             tokens.Select(t => t.Token).ToList());
 
-        BatchResponse response = await FirebaseMessaging.DefaultInstance.SendEachForMulticastAsync(message);
+        BatchResponse response = await FirebaseMessaging.DefaultInstance.SendEachForMulticastAsync(message, cancellationToken);
 
         _logger.LogInformation("FCM batch send completed. Success: {SuccessCount}, Failure: {FailureCount}",
             response.SuccessCount, response.FailureCount);
 
-        await HandleFailedTokensAsync(response, tokens);
+        await HandleFailedTokensAsync(response, tokens, cancellationToken);
     }
 
     public async Task<int> SendToTenantAsync(string tenantId, string title, string body, Dictionary<string, string>? data = null, CancellationToken cancellationToken = default)
@@ -163,28 +163,28 @@ public sealed class FirebasePushNotificationService : IPushNotificationService
         _logger.LogInformation("FCM tenant batch send completed. Success: {SuccessCount}, Failure: {FailureCount}",
             response.SuccessCount, response.FailureCount);
 
-        await HandleFailedTokensAsync(response, tokens);
+        await HandleFailedTokensAsync(response, tokens, cancellationToken);
 
         return response.SuccessCount;
     }
 
-    public async Task RegisterTokenAsync(RegisterPushTokenRequest request)
+    public async Task RegisterTokenAsync(RegisterPushTokenRequest request, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(request);
 
-        PushNotificationTokenEntity? existingToken = await _tokenRepository.GetByTokenAsync(request.Token);
+        PushNotificationTokenEntity? existingToken = await _tokenRepository.GetByTokenAsync(request.Token, cancellationToken);
 
         if (existingToken is not null)
         {
             if (!existingToken.IsActive)
             {
                 existingToken.Reactivate();
-                await _tokenRepository.UpdateAsync(existingToken);
+                await _tokenRepository.UpdateAsync(existingToken, cancellationToken);
             }
             else
             {
                 existingToken.UpdateLastUsed();
-                await _tokenRepository.UpdateAsync(existingToken);
+                await _tokenRepository.UpdateAsync(existingToken, cancellationToken);
             }
         }
         else
@@ -195,18 +195,18 @@ public sealed class FirebasePushNotificationService : IPushNotificationService
                 request.Token,
                 request.Platform);
 
-            await _tokenRepository.AddAsync(token);
+            await _tokenRepository.AddAsync(token, cancellationToken);
         }
 
         _logger.LogInformation("Registered push token for user {UserId} on platform {Platform}",
             request.UserId, request.Platform);
     }
 
-    public async Task UnregisterTokenAsync(string token)
+    public async Task UnregisterTokenAsync(string token, CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(token);
 
-        await _tokenRepository.DeactivateByTokenAsync(token);
+        await _tokenRepository.DeactivateByTokenAsync(token, cancellationToken);
 
         _logger.LogInformation("Unregistered push token");
     }
@@ -261,7 +261,7 @@ public sealed class FirebasePushNotificationService : IPushNotificationService
         };
     }
 
-    private async Task HandleFailedTokensAsync(BatchResponse response, List<PushNotificationTokenEntity> tokens)
+    private async Task HandleFailedTokensAsync(BatchResponse response, List<PushNotificationTokenEntity> tokens, CancellationToken cancellationToken)
     {
         if (response.FailureCount == 0)
             return;
@@ -281,7 +281,7 @@ public sealed class FirebasePushNotificationService : IPushNotificationService
             {
                 PushNotificationTokenEntity token = tokens[i];
                 token.Deactivate();
-                await _tokenRepository.UpdateAsync(token);
+                await _tokenRepository.UpdateAsync(token, cancellationToken);
 
                 _logger.LogWarning("Deactivated invalid push token due to error: {ErrorCode}", errorCode);
             }

--- a/Code/AppBlueprint/Shared-Modules/Infrastructure/AppBlueprint.Infrastructure.Notifications/NotificationService.cs
+++ b/Code/AppBlueprint/Shared-Modules/Infrastructure/AppBlueprint.Infrastructure.Notifications/NotificationService.cs
@@ -13,14 +13,14 @@ public sealed class NotificationService(
     IInAppNotificationService inAppService,
     IPushNotificationService pushService) : INotificationService
 {
-    public async Task SendAsync(SendNotificationRequest request)
+    public async Task SendAsync(SendNotificationRequest request, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(request);
 
         Console.WriteLine($"[NotificationService] SendAsync - TenantId: '{request.TenantId}', UserId: '{request.UserId}', Channels: {request.Channels}");
 
         // Get user preferences
-        NotificationPreferencesEntity? preferences = await preferencesRepository.GetByUserIdAsync(request.UserId);
+        NotificationPreferencesEntity? preferences = await preferencesRepository.GetByUserIdAsync(request.UserId, cancellationToken);
 
         // Create default preferences if none exist
         if (preferences is null)
@@ -28,7 +28,7 @@ public sealed class NotificationService(
             preferences = NotificationPreferencesEntity.CreateDefault(
                 request.TenantId,
                 request.UserId);
-            await preferencesRepository.AddAsync(preferences);
+            await preferencesRepository.AddAsync(preferences, cancellationToken);
         }
 
         // Check quiet hours
@@ -42,7 +42,7 @@ public sealed class NotificationService(
 
         if (request.Channels.HasFlag(NotificationChannels.InApp) && preferences.InAppEnabled)
         {
-            tasks.Add(inAppService.SendAsync(request));
+            tasks.Add(inAppService.SendAsync(request, cancellationToken));
         }
 
         if (request.Channels.HasFlag(NotificationChannels.Push) && preferences.PushEnabled)
@@ -56,41 +56,41 @@ public sealed class NotificationService(
                 Data: new Dictionary<string, string>
                 {
                     ["type"] = request.Type.ToString()
-                })));
+                }), cancellationToken));
         }
 
         await Task.WhenAll(tasks);
     }
 
-    public async Task<IEnumerable<UserNotificationEntity>> GetUserNotificationsAsync(string userId, int count = 20)
+    public async Task<IEnumerable<UserNotificationEntity>> GetUserNotificationsAsync(string userId, int count = 20, CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(userId);
 
-        List<UserNotificationEntity> notifications = await notificationRepository.GetByUserIdAsync(userId);
+        List<UserNotificationEntity> notifications = await notificationRepository.GetByUserIdAsync(userId, cancellationToken);
         return notifications.Take(count);
     }
 
-    public async Task<int> GetUnreadCountAsync(string userId)
+    public async Task<int> GetUnreadCountAsync(string userId, CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(userId);
-        return await notificationRepository.CountUnreadAsync(userId);
+        return await notificationRepository.CountUnreadAsync(userId, cancellationToken);
     }
 
-    public async Task MarkAsReadAsync(string notificationId)
+    public async Task MarkAsReadAsync(string notificationId, CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(notificationId);
 
-        UserNotificationEntity? notification = await notificationRepository.GetByIdAsync(notificationId);
+        UserNotificationEntity? notification = await notificationRepository.GetByIdAsync(notificationId, cancellationToken);
         if (notification is not null)
         {
             notification.MarkAsRead();
-            await notificationRepository.UpdateAsync(notification);
+            await notificationRepository.UpdateAsync(notification, cancellationToken);
         }
     }
 
-    public async Task MarkAllAsReadAsync(string userId)
+    public async Task MarkAllAsReadAsync(string userId, CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(userId);
-        await notificationRepository.MarkAllAsReadAsync(userId);
+        await notificationRepository.MarkAllAsReadAsync(userId, cancellationToken);
     }
 }

--- a/Code/AppBlueprint/Shared-Modules/Infrastructure/AppBlueprint.Infrastructure.Realtime/Notifications/InAppNotificationService.cs
+++ b/Code/AppBlueprint/Shared-Modules/Infrastructure/AppBlueprint.Infrastructure.Realtime/Notifications/InAppNotificationService.cs
@@ -13,7 +13,7 @@ public sealed class InAppNotificationService(
     INotificationRepository notificationRepository,
     IHubContext<NotificationHub> hubContext) : IInAppNotificationService
 {
-    public async Task SendAsync(SendNotificationRequest request)
+    public async Task SendAsync(SendNotificationRequest request, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(request);
 
@@ -28,7 +28,7 @@ public sealed class InAppNotificationService(
             request.Type,
             request.ActionUrl);
 
-        await notificationRepository.AddAsync(notification);
+        await notificationRepository.AddAsync(notification, cancellationToken);
 
         // Send real-time notification via SignalR
         await hubContext.Clients
@@ -41,6 +41,6 @@ public sealed class InAppNotificationService(
                 type = notification.Type,
                 actionUrl = notification.ActionUrl?.ToString(),
                 timestamp = notification.CreatedAt
-            });
+            }, cancellationToken);
     }
 }

--- a/Code/AppBlueprint/Shared-Modules/Infrastructure/AppBlueprint.Infrastructure.Realtime/Notifications/MultiChannelNotificationService.cs
+++ b/Code/AppBlueprint/Shared-Modules/Infrastructure/AppBlueprint.Infrastructure.Realtime/Notifications/MultiChannelNotificationService.cs
@@ -189,7 +189,7 @@ public sealed class MultiChannelNotificationService : IMultiChannelNotificationS
         {
             _logger.LogError(ex, "SignalR hub not available for tenant broadcast to {TenantId}", tenantId);
         }
-        catch (TaskCanceledException ex)
+        catch (TaskCanceledException ex) when (!cancellationToken.IsCancellationRequested)
         {
             _logger.LogWarning(ex, "SignalR tenant broadcast timed out for {TenantId}", tenantId);
         }
@@ -221,7 +221,7 @@ public sealed class MultiChannelNotificationService : IMultiChannelNotificationS
         {
             _logger.LogError(ex, "Push service not configured or available for user {UserId}", userId);
         }
-        catch (TaskCanceledException ex)
+        catch (TaskCanceledException ex) when (!cancellationToken.IsCancellationRequested)
         {
             _logger.LogWarning(ex, "Push notification request timed out for user {UserId}", userId);
         }
@@ -247,7 +247,7 @@ public sealed class MultiChannelNotificationService : IMultiChannelNotificationS
         {
             _logger.LogError(ex, "Push service not configured for tenant {TenantId}", tenantId);
         }
-        catch (TaskCanceledException ex)
+        catch (TaskCanceledException ex) when (!cancellationToken.IsCancellationRequested)
         {
             _logger.LogWarning(ex, "Tenant push notification timed out for {TenantId}", tenantId);
         }

--- a/Code/AppBlueprint/Shared-Modules/Infrastructure/AppBlueprint.Infrastructure.Realtime/Notifications/MultiChannelNotificationService.cs
+++ b/Code/AppBlueprint/Shared-Modules/Infrastructure/AppBlueprint.Infrastructure.Realtime/Notifications/MultiChannelNotificationService.cs
@@ -147,8 +147,8 @@ public sealed class MultiChannelNotificationService : IMultiChannelNotificationS
                 Message: message,
                 Type: type,
                 ActionUrl: actionUrl,
-                Channels: NotificationChannels.InApp
-            ));
+                Channels: NotificationChannels.InApp),
+                cancellationToken);
             _logger.LogDebug("Saved in-app notification for user {UserId}", userId);
         }
         catch (DbUpdateException ex)
@@ -209,7 +209,8 @@ public sealed class MultiChannelNotificationService : IMultiChannelNotificationS
                 Title: title,
                 Body: message,
                 Data: data
-            ));
+            ),
+            cancellationToken);
             _logger.LogDebug("Sent push notification to user {UserId}", userId);
         }
         catch (HttpRequestException ex)


### PR DESCRIPTION
## Summary
- Add `CancellationToken` parameters to the notification service interfaces and implementations.
- Propagate cancellation through notification repositories, Firebase Cloud Messaging sends, in-app notification persistence, SignalR delivery, and multi-channel notification call sites.
- Keep existing default-call behavior source-compatible by using `CancellationToken cancellationToken = default`.

## Testing
- `dotnet build Code/AppBlueprint/Shared-Modules/Infrastructure/AppBlueprint.Infrastructure.Notifications/AppBlueprint.Infrastructure.Notifications.csproj --no-restore`
- `dotnet build Code/AppBlueprint/Shared-Modules/Infrastructure/AppBlueprint.Infrastructure.Realtime/AppBlueprint.Infrastructure.Realtime.csproj --no-restore`
- `dotnet test --project Code/AppBlueprint/AppBlueprint.Tests/AppBlueprint.Tests.csproj --no-restore` with a temporary .NET 10 Microsoft.Testing.Platform `global.json` opt-in: 105 passed, 13 failed. The failures appear unrelated to this change and cover existing architecture/naming rules, a local Windows CodeQL path, and tenant integration fixture data.

Closes #329.

*This PR was developed by Codex with supervision from jmtdev0.*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds CancellationToken support across all notification services so request cancellation flows end-to-end (in-app, push, repositories, and SignalR). Also preserves caller cancellations by not logging them as timeouts. Addresses Linear #329.

- **Refactors**
  - Added optional CancellationToken to `INotificationService`, `IPushNotificationService`, and `IInAppNotificationService`.
  - Threaded tokens through repositories, Firebase batch sends, SignalR broadcasts, and multi-channel call sites.
  - Passed tokens through Firebase token lookups/updates and failed-token cleanup.
  - Enabled token-aware notification queries and mutations (get, unread count, mark read/all).

- **Bug Fixes**
  - Preserve caller cancellation in SignalR and push paths by not treating them as timeouts; log only genuine timeouts.

<sup>Written for commit ea52812e1dd9db3daf89f5c7b2e4cc766c076d83. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/saas-factory-labs/SaaS-Factory/pull/330?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Notification actions now support cancellation, helping stop in-progress sends, token updates, and notification lookups more cleanly.
* **Bug Fixes**
  * Improved notification delivery and inbox operations to better handle interrupted requests and reduce unnecessary work during long-running actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->